### PR TITLE
Update comment in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
     outputs
     // {
       # Overlay that can be imported so you can access the packages
-      # using zigpkgs.master.latest or whatever you'd like.
+      # using zigpkgs.master or whatever you'd like.
       overlays.default = final: prev: {
         zigpkgs = outputs.packages.${prev.system};
       };


### PR DESCRIPTION
This is a small change to a comment in flake.nix. The comment recommend using `zigpkgs.master.latest` which doesn't exist when I tried using the overlay.