### PR TITLE
Download releases, verify signature, and compute SHA256

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# If we are a computer with nix-shell available, then use that to setup
+# the build environment with exactly what we need.
+if has nix; then
+  use nix
+fi

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1659877975,
@@ -33,6 +49,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+
+    # Used for shell.nix
+    flake-compat = {
+      url = github:edolstra/flake-compat;
+      flake = false;
+    };
   };
 
   outputs = {
@@ -32,6 +38,16 @@
 
       # nix fmt
       formatter = pkgs.alejandra;
+
+      devShells.default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [
+          curl
+          jq
+        ];
+      };
+
+      # For compatibility with older versions of the `nix` binary
+      devShell = self.devShells.${system}.default;
     });
   in
     outputs

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
         nativeBuildInputs = with pkgs; [
           curl
           jq
+          minisign
           python3Full
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
         nativeBuildInputs = with pkgs; [
           curl
           jq
+          python3Full
         ];
       };
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+(import
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix

--- a/sources.json
+++ b/sources.json
@@ -38,31 +38,31 @@
       "x86_64-linux": {
         "url": "https://ziglang.org/builds/zig-linux-x86_64-0.11.0-dev.1327+b42bd759a.tar.xz",
         "version": "0.11.0-dev.1327+b42bd759a",
-        "sha256": null
+        "sha256": "c62c063d34a5987dfb4f21a83af4865de7180137d1a7d18038e5f0d2249813d2"
       },
       "aarch64-linux": {
         "url": "https://ziglang.org/builds/zig-linux-aarch64-0.11.0-dev.1327+b42bd759a.tar.xz",
         "version": "0.11.0-dev.1327+b42bd759a",
-        "sha256": null
+        "sha256": "8a581204681a6cdfcbca60c6d8dfea7e12bf7faba772befe09eb25dc53759dc1"
       },
       "x86_64-darwin": {
         "url": "https://ziglang.org/builds/zig-macos-x86_64-0.11.0-dev.1327+b42bd759a.tar.xz",
         "version": "0.11.0-dev.1327+b42bd759a",
-        "sha256": null
+        "sha256": "04998ae452ba3fcccdadde4cb954096541cf15ad17aaed8a30a294ed396b7076"
       },
       "aarch64-darwin": {
         "url": "https://ziglang.org/builds/zig-macos-aarch64-0.11.0-dev.1327+b42bd759a.tar.xz",
         "version": "0.11.0-dev.1327+b42bd759a",
-        "sha256": null
+        "sha256": "44fd80b59dd8ef515bdccf66760191188948d4a396981f6ce769c346f527df3d"
       },
       "x86_64-windows": {
         "url": "https://ziglang.org/builds/zig-windows-x86_64-0.11.0-dev.1327+b42bd759a.zip",
-        "sha256": null,
+        "sha256": "037822e3d90955746724833629e95ddfb46f59778b1ee9bef14d5dac259ee958",
         "version": "0.11.0-dev.1327+b42bd759a"
       },
       "aarch64-windows": {
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.11.0-dev.1327+b42bd759a.zip",
-        "sha256": null,
+        "sha256": "a4966d4ac10cfecdb87d6072d00c589aca927d14216eac794b64834a63b652db",
         "version": "0.11.0-dev.1327+b42bd759a"
       }
     },
@@ -10679,63 +10679,69 @@
       "x86_64-darwin": {
         "url": "https://ziglang.org/builds/zig-macos-x86_64-0.11.0-dev.1314+9856bea34.tar.xz",
         "sha256": null,
-        "version": "0.11.0-dev.1314+9856bea34"
+        "version": "0.11.0-dev.1314+9856bea34",
+        "broken": true
       },
       "aarch64-darwin": {
         "url": "https://ziglang.org/builds/zig-macos-aarch64-0.11.0-dev.1314+9856bea34.tar.xz",
         "sha256": null,
-        "version": "0.11.0-dev.1314+9856bea34"
+        "version": "0.11.0-dev.1314+9856bea34",
+        "broken": true
       },
       "x86_64-linux": {
         "url": "https://ziglang.org/builds/zig-linux-x86_64-0.11.0-dev.1314+9856bea34.tar.xz",
         "sha256": null,
-        "version": "0.11.0-dev.1314+9856bea34"
+        "version": "0.11.0-dev.1314+9856bea34",
+        "broken": true
       },
       "aarch64-linux": {
         "url": "https://ziglang.org/builds/zig-linux-aarch64-0.11.0-dev.1314+9856bea34.tar.xz",
         "sha256": null,
-        "version": "0.11.0-dev.1314+9856bea34"
+        "version": "0.11.0-dev.1314+9856bea34",
+        "broken": true
       },
       "x86_64-windows": {
         "url": "https://ziglang.org/builds/zig-windows-x86_64-0.11.0-dev.1314+9856bea34.zip",
         "sha256": null,
-        "version": "0.11.0-dev.1314+9856bea34"
+        "version": "0.11.0-dev.1314+9856bea34",
+        "broken": true
       },
       "aarch64-windows": {
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.11.0-dev.1314+9856bea34.zip",
         "sha256": null,
-        "version": "0.11.0-dev.1314+9856bea34"
+        "version": "0.11.0-dev.1314+9856bea34",
+        "broken": true
       }
     },
     "2023-01-17": {
       "x86_64-darwin": {
         "url": "https://ziglang.org/builds/zig-macos-x86_64-0.11.0-dev.1327+b42bd759a.tar.xz",
-        "sha256": null,
+        "sha256": "04998ae452ba3fcccdadde4cb954096541cf15ad17aaed8a30a294ed396b7076",
         "version": "0.11.0-dev.1327+b42bd759a"
       },
       "aarch64-darwin": {
         "url": "https://ziglang.org/builds/zig-macos-aarch64-0.11.0-dev.1327+b42bd759a.tar.xz",
-        "sha256": null,
+        "sha256": "44fd80b59dd8ef515bdccf66760191188948d4a396981f6ce769c346f527df3d",
         "version": "0.11.0-dev.1327+b42bd759a"
       },
       "x86_64-linux": {
         "url": "https://ziglang.org/builds/zig-linux-x86_64-0.11.0-dev.1327+b42bd759a.tar.xz",
-        "sha256": null,
+        "sha256": "c62c063d34a5987dfb4f21a83af4865de7180137d1a7d18038e5f0d2249813d2",
         "version": "0.11.0-dev.1327+b42bd759a"
       },
       "aarch64-linux": {
         "url": "https://ziglang.org/builds/zig-linux-aarch64-0.11.0-dev.1327+b42bd759a.tar.xz",
-        "sha256": null,
+        "sha256": "8a581204681a6cdfcbca60c6d8dfea7e12bf7faba772befe09eb25dc53759dc1",
         "version": "0.11.0-dev.1327+b42bd759a"
       },
       "x86_64-windows": {
         "url": "https://ziglang.org/builds/zig-windows-x86_64-0.11.0-dev.1327+b42bd759a.zip",
-        "sha256": null,
+        "sha256": "037822e3d90955746724833629e95ddfb46f59778b1ee9bef14d5dac259ee958",
         "version": "0.11.0-dev.1327+b42bd759a"
       },
       "aarch64-windows": {
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.11.0-dev.1327+b42bd759a.zip",
-        "sha256": null,
+        "sha256": "a4966d4ac10cfecdb87d6072d00c589aca927d14216eac794b64834a63b652db",
         "version": "0.11.0-dev.1327+b42bd759a"
       }
     }
@@ -10744,17 +10750,17 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.7.1/zig-linux-x86_64-0.7.1.tar.xz",
       "version": "0.7.1",
-      "sha256": null
+      "sha256": "18c7b9b200600f8bcde1cd8d7f1f578cbc3676241ce36d771937ce19a8159b8d"
     },
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.7.1/zig-linux-aarch64-0.7.1.tar.xz",
       "version": "0.7.1",
-      "sha256": null
+      "sha256": "48ec90eba407e4587ddef7eecef25fec7e13587eb98e3b83c5f2f5fff2a5cbe7"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.7.1/zig-macos-x86_64-0.7.1.tar.xz",
       "version": "0.7.1",
-      "sha256": null
+      "sha256": "845cb17562978af0cf67e3993f4e33330525eaf01ead9386df9105111e3bc519"
     },
     "aarch64-darwin": {
       "url": null,
@@ -10763,7 +10769,7 @@
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.7.1/zig-windows-x86_64-0.7.1.zip",
-      "sha256": null,
+      "sha256": "4818a8a65b4672bc52c0ae7f14d014e0eb8caf10f12c0745176820384cea296a",
       "version": "0.7.1"
     }
   },
@@ -10771,26 +10777,26 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.7.0/zig-linux-x86_64-0.7.0.tar.xz",
       "version": "0.7.0",
-      "sha256": null
+      "sha256": "e619b1c6094c095b932767f527aee2507f847ea981513ff8a08aab0fd730e0ac"
     },
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.7.0/zig-linux-aarch64-0.7.0.tar.xz",
       "version": "0.7.0",
-      "sha256": null
+      "sha256": "f89933bac87d44be82325754ff88423020c81c7032a6fc41cfeb81e982eeab9b"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.7.0/zig-macos-x86_64-0.7.0.tar.xz",
       "version": "0.7.0",
-      "sha256": null
+      "sha256": "94063f9a311cbbf7a2e0a12295e09437182cf950f18cb0eb30ea9893f3677f24"
     },
     "aarch64-darwin": {
       "url": "https://ziglang.org/download/0.7.0/zig-macos-aarch64-0.7.0.tar.xz",
       "version": "0.7.0",
-      "sha256": null
+      "sha256": "338238035734db74ea4f30e500a4893bf741d38305c10952d5e39fa05bdb057d"
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.7.0/zig-windows-x86_64-0.7.0.zip",
-      "sha256": null,
+      "sha256": "965f56c0a36f9cda2125e3a348bc654f7f155e2804c3667d231775ec228f8553",
       "version": "0.7.0"
     }
   },
@@ -10798,17 +10804,17 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.6.0/zig-linux-x86_64-0.6.0.tar.xz",
       "version": "0.6.0",
-      "sha256": null
+      "sha256": "08fd3c757963630645441c2772362e9c2294020c44f14fce1b89f45de0dc1253"
     },
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.6.0/zig-linux-aarch64-0.6.0.tar.xz",
       "version": "0.6.0",
-      "sha256": null
+      "sha256": "e7520efd42cfa02be48c2e430d08fe1f3cbb999d21d9f0d3ffd0febb976b2f41"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.6.0/zig-macos-x86_64-0.6.0.tar.xz",
       "version": "0.6.0",
-      "sha256": null
+      "sha256": "17270360e87ddc49f737e760047b2fac49f1570a824a306119b1194ac4093895"
     },
     "aarch64-darwin": {
       "url": null,
@@ -10817,7 +10823,7 @@
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.6.0/zig-windows-x86_64-0.6.0.zip",
-      "sha256": null,
+      "sha256": "c3b897832523e1026e10b2d8d55d7f895185c0a27a63681f3a23219c3f1c38f4",
       "version": "0.6.0"
     }
   },
@@ -10825,7 +10831,7 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.5.0/zig-linux-x86_64-0.5.0.tar.xz",
       "version": "0.5.0",
-      "sha256": null
+      "sha256": "43e8f8a8b8556edd373ddf9c1ef3ca6cf852d4d09fe07d5736d12fefedd2b4f7"
     },
     "aarch64-linux": {
       "url": null,
@@ -10835,7 +10841,7 @@
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.5.0/zig-macos-x86_64-0.5.0.tar.xz",
       "version": "0.5.0",
-      "sha256": null
+      "sha256": "28702cc05745c7c0bd450487d5f4091bf0a1ad279b35eb9a640ce3e3a15b300d"
     },
     "aarch64-darwin": {
       "url": null,
@@ -10844,7 +10850,7 @@
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.5.0/zig-windows-x86_64-0.5.0.zip",
-      "sha256": null,
+      "sha256": "58141323db8d84a5af62746be5f9140bc161ee760ef33dc91a887bf9ac021976",
       "version": "0.5.0"
     }
   },
@@ -10852,7 +10858,7 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.4.0/zig-linux-x86_64-0.4.0.tar.xz",
       "version": "0.4.0",
-      "sha256": null
+      "sha256": "fb1954e2fb556a01f8079a08130e88f70084e08978ff853bb2b1986d8c39d84e"
     },
     "aarch64-linux": {
       "url": null,
@@ -10862,7 +10868,7 @@
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.4.0/zig-macos-x86_64-0.4.0.tar.xz",
       "version": "0.4.0",
-      "sha256": null
+      "sha256": "67c932982484d017c5111e54af9f33f15e8e05c6bc5346a55e04052159c964a8"
     },
     "aarch64-darwin": {
       "url": null,
@@ -10871,7 +10877,7 @@
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.4.0/zig-windows-x86_64-0.4.0.zip",
-      "sha256": null,
+      "sha256": "fbc3dd205e064c263063f69f600bedb18e3d0aa2efa747a63ef6cafb6d73f127",
       "version": "0.4.0"
     }
   },
@@ -10879,7 +10885,7 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.3.0/zig-linux-x86_64-0.3.0.tar.xz",
       "version": "0.3.0",
-      "sha256": null
+      "sha256": "b378d0aae30cb54f28494e7bc4efbc9bfb6326f47bfb302e8b5287af777b2f3c"
     },
     "aarch64-linux": {
       "url": null,
@@ -10889,7 +10895,7 @@
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.3.0/zig-macos-x86_64-0.3.0.tar.xz",
       "version": "0.3.0",
-      "sha256": null
+      "sha256": "19dec1f1943ab7be26823376d466f7e456143deb34e17502778a949034dc2e7e"
     },
     "aarch64-darwin": {
       "url": null,
@@ -10898,7 +10904,7 @@
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.3.0/zig-windows-x86_64-0.3.0.zip",
-      "sha256": null,
+      "sha256": "bb568c03950958f8bb3472139c3ab5ed74547c8c694ab50f404c202faf51baf4",
       "version": "0.3.0"
     }
   },
@@ -10906,7 +10912,7 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.2.0/zig-linux-x86_64-0.2.0.tar.xz",
       "version": "0.2.0",
-      "sha256": null
+      "sha256": "209c6fb745d42474c0a73d6f291c7ae3a38b6a1b6b641eea285a7f840cc1a890"
     },
     "aarch64-linux": {
       "url": null,
@@ -10925,7 +10931,7 @@
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.2.0/zig-win64-0.2.0.zip",
-      "sha256": null,
+      "sha256": "4f8a2979941a1f081ec8e545cca0b72608c0db1c5a3fd377a94db40649dcd3d4",
       "version": "0.2.0"
     }
   },
@@ -10952,7 +10958,7 @@
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.1.1/zig-win64-0.1.1.zip",
-      "sha256": null,
+      "sha256": "6fc88bef531af7e567fe30bf60da1487b86833cbee84c7a2f3e317030aa5b660",
       "version": "0.1.1"
     }
   },
@@ -10960,26 +10966,26 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.8.0/zig-linux-x86_64-0.8.0.tar.xz",
       "version": "0.8.0",
-      "sha256": null
+      "sha256": "502625d3da3ae595c5f44a809a87714320b7a40e6dff4a895b5fa7df3391d01e"
     },
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.8.0/zig-linux-aarch64-0.8.0.tar.xz",
       "version": "0.8.0",
-      "sha256": null
+      "sha256": "ee204ca2c2037952cf3f8b10c609373a08a291efa4af7b3c73be0f2b27720470"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.8.0/zig-macos-x86_64-0.8.0.tar.xz",
       "version": "0.8.0",
-      "sha256": null
+      "sha256": "279f9360b5cb23103f0395dc4d3d0d30626e699b1b4be55e98fd985b62bc6fbe"
     },
     "aarch64-darwin": {
       "url": "https://ziglang.org/download/0.8.0/zig-macos-aarch64-0.8.0.tar.xz",
       "version": "0.8.0",
-      "sha256": null
+      "sha256": "b32d13f66d0e1ff740b3326d66a469ee6baddbd7211fa111c066d3bd57683111"
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.8.0/zig-windows-x86_64-0.8.0.zip",
-      "sha256": null,
+      "sha256": "8580fbbf3afb72e9b495c7f8aeac752a03475ae0bbcf5d787f3775c7e1f4f807",
       "version": "0.8.0"
     }
   },
@@ -10987,26 +10993,26 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.8.1/zig-linux-x86_64-0.8.1.tar.xz",
       "version": "0.8.1",
-      "sha256": null
+      "sha256": "6c032fc61b5d77a3f3cf781730fa549f8f059ffdb3b3f6ad1c2994d2b2d87983"
     },
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.8.1/zig-linux-aarch64-0.8.1.tar.xz",
       "version": "0.8.1",
-      "sha256": null
+      "sha256": "2166dc9f2d8df387e8b4122883bb979d739281e1ff3f3d5483fec3a23b957510"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.8.1/zig-macos-x86_64-0.8.1.tar.xz",
       "version": "0.8.1",
-      "sha256": null
+      "sha256": "16b0e1defe4c1807f2e128f72863124bffdd906cefb21043c34b673bf85cd57f"
     },
     "aarch64-darwin": {
       "url": "https://ziglang.org/download/0.8.1/zig-macos-aarch64-0.8.1.tar.xz",
       "version": "0.8.1",
-      "sha256": null
+      "sha256": "5351297e3b8408213514b29c0a938002c5cf9f97eee28c2f32920e1227fd8423"
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.8.1/zig-windows-x86_64-0.8.1.zip",
-      "sha256": null,
+      "sha256": "43573db14cd238f7111d6bdf37492d363f11ecd1eba802567a172f277d003926",
       "version": "0.8.1"
     }
   },
@@ -11014,31 +11020,31 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.9.0/zig-linux-x86_64-0.9.0.tar.xz",
       "version": "0.9.0",
-      "sha256": null
+      "sha256": "5c55344a877d557fb1b28939785474eb7f4f2f327aab55293998f501f7869fa6"
     },
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.9.0/zig-linux-aarch64-0.9.0.tar.xz",
       "version": "0.9.0",
-      "sha256": null
+      "sha256": "1524fedfdbade2dbc9bae1ed98ad38fa7f2114c9a3e94da0d652573c75efbc5a"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.9.0/zig-macos-x86_64-0.9.0.tar.xz",
       "version": "0.9.0",
-      "sha256": null
+      "sha256": "c5280eeec4d6e5ea5ce5b448dc9a7c4bdd85ecfed4c1b96aa0835e48b36eccf0"
     },
     "aarch64-darwin": {
       "url": "https://ziglang.org/download/0.9.0/zig-macos-aarch64-0.9.0.tar.xz",
       "version": "0.9.0",
-      "sha256": null
+      "sha256": "3991c70594d61d09fb4b316157a7c1d87b1d4ec159e7a5ecd11169ff74cad832"
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.9.0/zig-windows-x86_64-0.9.0.zip",
-      "sha256": null,
+      "sha256": "084ea2646850aaf068234b0f1a92b914ed629be47075e835f8a67d55c21d880e",
       "version": "0.9.0"
     },
     "aarch64-windows": {
       "url": "https://ziglang.org/download/0.9.0/zig-windows-aarch64-0.9.0.zip",
-      "sha256": null,
+      "sha256": "f9018725e3fb2e8992b17c67034726971156eb190685018a9ac8c3a9f7a22340",
       "version": "0.9.0"
     }
   },
@@ -11046,63 +11052,63 @@
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.9.1/zig-linux-x86_64-0.9.1.tar.xz",
       "version": "0.9.1",
-      "sha256": null
+      "sha256": "be8da632c1d3273f766b69244d80669fe4f5e27798654681d77c992f17c237d7"
     },
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.9.1/zig-linux-aarch64-0.9.1.tar.xz",
       "version": "0.9.1",
-      "sha256": null
+      "sha256": "5d99a39cded1870a3fa95d4de4ce68ac2610cca440336cfd252ffdddc2b90e66"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.9.1/zig-macos-x86_64-0.9.1.tar.xz",
       "version": "0.9.1",
-      "sha256": null
+      "sha256": "2d94984972d67292b55c1eb1c00de46580e9916575d083003546e9a01166754c"
     },
     "aarch64-darwin": {
       "url": "https://ziglang.org/download/0.9.1/zig-macos-aarch64-0.9.1.tar.xz",
       "version": "0.9.1",
-      "sha256": null
+      "sha256": "8c473082b4f0f819f1da05de2dbd0c1e891dff7d85d2c12b6ee876887d438287"
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.9.1/zig-windows-x86_64-0.9.1.zip",
-      "sha256": null,
+      "sha256": "443da53387d6ae8ba6bac4b3b90e9fef4ecbe545e1c5fa3a89485c36f5c0e3a2",
       "version": "0.9.1"
     },
     "aarch64-windows": {
       "url": "https://ziglang.org/download/0.9.1/zig-windows-aarch64-0.9.1.zip",
-      "sha256": null,
+      "sha256": "621bf95f54dc3ff71466c5faae67479419951d7489e40e87fd26d195825fb842",
       "version": "0.9.1"
     }
   },
   "0.10.0": {
     "aarch64-linux": {
       "url": "https://ziglang.org/download/0.10.0/zig-linux-aarch64-0.10.0.tar.xz",
-      "sha256": null,
+      "sha256": "09ef50c8be73380799804169197820ee78760723b0430fa823f56ed42b06ea0f",
       "version": "0.10.0"
     },
     "x86_64-linux": {
       "url": "https://ziglang.org/download/0.10.0/zig-linux-x86_64-0.10.0.tar.xz",
-      "sha256": null,
+      "sha256": "631ec7bcb649cd6795abe40df044d2473b59b44e10be689c15632a0458ddea55",
       "version": "0.10.0"
     },
     "aarch64-darwin": {
       "url": "https://ziglang.org/download/0.10.0/zig-macos-aarch64-0.10.0.tar.xz",
-      "sha256": null,
+      "sha256": "02f7a7839b6a1e127eeae22ea72c87603fb7298c58bc35822a951479d53c7557",
       "version": "0.10.0"
     },
     "x86_64-darwin": {
       "url": "https://ziglang.org/download/0.10.0/zig-macos-x86_64-0.10.0.tar.xz",
-      "sha256": null,
+      "sha256": "3a22cb6c4749884156a94ea9b60f3a28cf4e098a69f08c18fbca81c733ebfeda",
       "version": "0.10.0"
     },
     "x86_64-windows": {
       "url": "https://ziglang.org/download/0.10.0/zig-windows-x86_64-0.10.0.zip",
-      "sha256": null,
+      "sha256": "a66e2ff555c6e48781de1bcb0662ef28ee4b88af3af2a577f7b1950e430897ee",
       "version": "0.10.0"
     },
     "aarch64-windows": {
       "url": "https://ziglang.org/download/0.10.0/zig-windows-aarch64-0.10.0.zip",
-      "sha256": null,
+      "sha256": "1bbda8d123d44f3ae4fa90d0da04b1e9093c3f9ddae3429a4abece1e1c0bf19a",
       "version": "0.10.0"
     }
   }

--- a/update
+++ b/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -p curl jq -i sh
+#! nix-shell -p curl jq python3Full -i sh
 set -e
 
 # Build our new sources.json
@@ -42,3 +42,6 @@ cp sources.json sources.old.json
 
 # Recursive merge
 jq -s '.[0] * .[1]' sources.old.json sources.new.json > sources.json
+
+# Verify new release signatures and compute the SHA-256 sum.
+python verify_and_hash.py

--- a/update
+++ b/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -p curl jq python3Full -i sh
+#! nix-shell -p curl jq minisign python3Full -i sh
 set -e
 
 # Build our new sources.json

--- a/update
+++ b/update
@@ -6,16 +6,19 @@ set -e
 curl -s 'https://ziglang.org/download/index.json' | jq '
 ["aarch64-linux", "x86_64-linux", "aarch64-macos", "x86_64-macos", "aarch64-windows", "x86_64-windows"] as $targets |
 def todarwin(x): x | gsub("macos"; "darwin");
-def toentry(vsn; x):
+def toentry(vsn; x; clobber_sha):
   [(vsn as $version |
     .value |
     to_entries[] |
     select(.key as $key | any($targets[]; . == $key)) | {
-      (todarwin(.key)): {
+      (todarwin(.key)): ({
         "url": .value.tarball,
-        "sha256": .value.shasum,
         "version": $version,
-      }
+      } + (if (clobber_sha) then
+        { "sha256": .value.shasum }
+      else
+        {}
+      end))
     }
   )] | add | first(values, {});
 
@@ -23,10 +26,10 @@ reduce to_entries[] as $entry ({}; . * (
   $entry | {
     (.key): (
       if (.key != "master") then
-        toentry(.key; .value)
+        toentry(.key; .value; false)
       else {
-        "latest": toentry(.value.version; .value),
-        (.value.date): toentry(.value.version; .value),
+        "latest": toentry(.value.version; .value; true),
+        (.value.date): toentry(.value.version; .value; true),
       } end
     )
   }

--- a/verify_and_hash.py
+++ b/verify_and_hash.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -p python3Full -i python
+import hashlib
+import json
+import subprocess
+import urllib.request
+
+LOCAL_JSON_PATH = "sources.json"
+ZIG_JSON_URL = "https://ziglang.org/download/index.json"
+PLATFORMS = {"aarch64-linux", "x86_64-linux", "aarch64-macos", "x86_64-macos", "aarch64-windows", "x86_64-windows"}
+PUBLIC_KEY = "RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
+
+def fix_release(release):
+    "Fix all the null SHA256 entries in a single release."
+    for platform_key in release:
+        platform = release[platform_key]
+        if platform["sha256"] != None or platform["url"] == None:
+            continue
+        print(f'fixing version={platform["version"]} platform={platform_key}')
+
+        try:
+            sigfile, _ = urllib.request.urlretrieve(platform["url"] + ".minisig")
+            binfile, _ = urllib.request.urlretrieve(platform["url"])
+
+            sigcheck = subprocess.run([
+                "minisign",
+                "-V",
+                "-P", PUBLIC_KEY,
+                "-x", sigfile,
+                "-m", binfile,
+            ], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            if sigcheck.returncode != 0:
+                print('  failed signature check!')
+                continue
+
+            platform["sha256"] = sha256_file(binfile)
+        except urllib.error.HTTPError as e:
+            # 403 is semantically 404 for Zig
+            if e.code == 403:
+                platform["broken"] = True
+            else:
+                print(f'  failed download: {e}')
+        finally:
+            urllib.request.urlcleanup()
+
+def sha256_file(file_name):
+    "Compute the SHA256 hash of a file."
+    h = hashlib.sha256()
+    with open(file_name, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+def main():
+    """
+    This "fixes" our sources.json by finding all releases with a null sha256
+    and computing the value. Prior to computing the value, we validate the
+    signature, too.
+
+    We should probably merge all of ./update logic into here, but I bolted
+    this on at some point because it works. Contributions welcome!
+    """
+    # Load our local sources
+    with open(LOCAL_JSON_PATH, encoding="utf-8") as f:
+        local = json.load(f)
+
+    # Go through master releases
+    for release_name in local:
+        release = local[release_name]
+
+        if release_name == "master":
+            for date in release:
+                fix_release(release[date])
+        else:
+            fix_release(release)
+
+    # Save
+    with open(LOCAL_JSON_PATH, "w", encoding="utf-8") as f:
+        json.dump(local, f, indent=2)
+
+if __name__ == "__main__":
+    main()

--- a/verify_and_hash.py
+++ b/verify_and_hash.py
@@ -39,6 +39,7 @@ def fix_release(release):
             # 403 is semantically 404 for Zig
             if e.code == 403:
                 platform["broken"] = True
+                platform["sha256"] = "BROKEN. THIS IS PURPOSELY INVALID."
             else:
                 print(f'  failed download: {e}')
         finally:


### PR DESCRIPTION
Fixes #12 

This adds a python script that is run after we update our sources that goes through and downloads all the releases that we don't yet have a checksum for, verifies the signature, and updates the checksum. 

This isn't perfect: on every update (every 6h) we reverify all the master releases. The fix is to just convert our shell+jq script to all Python so we can be smarter about it. 

But, in the interest of unbreaking latest releases, I want to merge this.