### PR TITLE
quote URLs in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
 
     # Used for shell.nix
     flake-compat = {
-      url = github:edolstra/flake-compat;
+      url = "github:edolstra/flake-compat";
       flake = false;
     };
   };


### PR DESCRIPTION
While the Nix language allows for URL literals, unquoted URLs are being deprecated and their usage is discouraged.

https://nixos.org/manual/nix/stable/contributing/experimental-features.html#xp-feature-no-url-literals
