### PR TITLE
Expose setup hook (closes #33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ index.json
 index.json.minisig
 sources.old.json
 sources.new.json
+.direnv/

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@
     version,
     sha256,
   }:
-    pkgs.stdenv.mkDerivation {
+    pkgs.stdenv.mkDerivation (finalAttrs: {
       inherit version;
 
       pname = "zig";
@@ -26,7 +26,17 @@
         cp -r lib/* $out/lib
         cp zig $out/bin/zig
       '';
-    };
+
+      passthru.hook = pkgs.zig.hook.override {zig = finalAttrs.finalPackage;};
+
+      meta = with pkgs.lib; {
+        description = "General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software";
+        homepage = "https://ziglang.org/";
+        license = lib.licenses.mit;
+        maintainers = [];
+        platforms = lib.platforms.unix;
+      };
+    });
 
   # The packages that are tagged releases
   taggedPackages =

--- a/flake.lock
+++ b/flake.lock
@@ -33,16 +33,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689088367,
-        "narHash": "sha256-Y2tl2TlKCWEHrOeM9ivjCLlRAKH3qoPUE/emhZECU14=",
+        "lastModified": 1702565688,
+        "narHash": "sha256-Rlbeq5iV1y1r69tYmEMz9aiIjFcbqLulkwr5OvG4pT8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c9ddb86679c400d6b7360797b8a22167c2053f8",
+        "rev": "1190e17452013669665b163a017cd7f62a290daa",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Zig compiler binaries.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
     flake-utils.url = "github:numtide/flake-utils";
 
     # Used for shell.nix


### PR DESCRIPTION
This PR exposes a useful setup hook introduced to nixpkgs in https://github.com/NixOS/nixpkgs/commit/a85a699e40708b452d36c70725396ff67dc48e66.

This required updating the `nixpkgs` input from 23.05 to 23.11 and adding a `meta` section.