### PR TITLE
flakes: use stable release branches for `nixpkgs` inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,16 +33,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689088367,
-        "narHash": "sha256-Y2tl2TlKCWEHrOeM9ivjCLlRAKH3qoPUE/emhZECU14=",
+        "lastModified": 1702350026,
+        "narHash": "sha256-A+GNZFZdfl4JdDphYKBJ5Ef1HOiFsP18vQe9mqjmUis=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c9ddb86679c400d6b7360797b8a22167c2053f8",
+        "rev": "9463103069725474698139ab10f17a9d125da859",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.05",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Zig compiler binaries.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
 
     # Used for shell.nix

--- a/templates/init/flake.nix
+++ b/templates/init/flake.nix
@@ -2,7 +2,7 @@
   description = "An empty project that uses Zig.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     zig.url = "github:mitchellh/zig-overlay";
 


### PR DESCRIPTION
#### Copy of commit msg
This is the best practice for Flakes or clients of nixpkgs in general.

The `release-<YY.MM>` branch is actually a dev branch:
Hydra continually tests the tip of this branch.
When the tests succeed, the `nixos-<YY.MM>` release branch is updated to point to the succeeding commit.

`release-<YY.MM>` is to `nixos-<YY.MM>` what `master` is to `nixpkgs-unstable`.

See also: https://github.com/NixOS/nixpkgs/blob/e88fb997e32982a5f37b933583e618265a32d85d/CONTRIBUTING.md#flow-of-merged-pull-requests