### PR TITLE
Add information on how to add zig-overlay as zigpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ In your `flake.nix` file:
   };
 }
 ```
-
 In a shell:
 
 ```sh
@@ -44,7 +43,35 @@ $ nix shell 'github:mitchellh/zig-overlay#master-2021-02-13'
 # open a shell with latest nightly version
 $ nix shell 'github:mitchellh/zig-overlay#master'
 ```
+### Adding zig as a package
 
+To access zig as a package:
+  In your `flake.nix` file:
+  
+```nix
+{
+  inputs.zig.url = "github:mitchellh/zig-overlay";
+
+  outputs = { self, zig, ... }: {
+    ...
+    modules = [
+      {nixpkgs.overlays = [zig.overlays.default];}
+      ...
+      ...
+    ];
+  };
+}
+```
+In your `configuration.nix` file :
+
+```nix
+    {pkgs,inputs, ...}: {
+    ...
+    environment.systemPackages = [
+      pkgs.zigpkgs.master # or <version>/master-<date>/
+    ]
+}
+```
 ### Compiler Development
 
 This flake outputs a template that makes it easy to work on the Zig

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ $ nix shell 'github:mitchellh/zig-overlay#master'
 ### Adding zig as a package
 
 To access zig as a package:
-  In your `flake.nix` file:
+
+In your `flake.nix` file:
   
 ```nix
 {


### PR DESCRIPTION
In a good amount of time I tried to install zig on my NixOS system and totally immerse myself in this good language. The only solid way was to use `zig-overlay`,  but the problem was running zig only once or in a `nix-shell`, which was not suitable for my wants. Also after cleanup you need to recompile ~300MB to run zig, which takes some time.

Fortunately, I stumbled upon docs in `flake.nix` file and decided to make installing nightly zig as a package easier for others by adding this block in the README.

What changed in the README:
- Added header about package
- Added code about `flake.nix `modules
- Added code about adding package to `configuration.nix`