### PR TITLE
Added /usr/bin/env fix from nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,8 @@
         [ -d docs ] && cp -r docs/* $out/doc
         [ -d doc ] && cp -r doc/* $out/doc
         cp -r lib/* $out/lib
+        substituteInPlace $out/lib/std/zig/system.zig \
+          --replace "/usr/bin/env" "${pkgs.lib.getExe' pkgs.coreutils "env"}"
         cp zig $out/bin/zig
       '';
     };


### PR DESCRIPTION
Currently, when using zig-overlay to compile zig code in a nix flake via `nix build` or the other nix-based build commands, which run the build in a nix sandbox, it will throw `error.FileNotFound` when attempting to detect the ABI and the linker, and will always fall back to the default one.
This patch to `lib/std/zig/system.zig` replaces the hardcoded `/usr/bin/env` path with a reference to the nix store coreutils bin/env path, which is pulled from the nixpkgs input of the flake.

Offending code:
https://github.com/ziglang/zig/blob/d5db02728ce3ff3ba74a3e3f9050c3ea9ed34752/lib/std/zig/system.zig#L1088

Patch source:
https://github.com/NixOS/nixpkgs/blob/5df43628fdf08d642be8ba5b3625a6c70731c19c/pkgs/development/compilers/zig/0.13/default.nix#L73-L78

Patched zig example:
![image](https://github.com/user-attachments/assets/66963394-6057-471d-bc79-1a6ebecc0acc)

It also pollutes the comments in that file that mention /usr/bin/env, but that's not really an issue