### PR TITLE
add meta.mainProgram

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,8 @@
         cp -r lib/* $out/lib
         cp zig $out/bin/zig
       '';
+
+      meta.mainProgram = "zig";
     };
 
   # The packages that are tagged releases


### PR DESCRIPTION
`lib.getExe zig` will no longer show the warnings.