### PR TITLE
Add Mach nominated versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+index.json
 zig-index.json
 zig-index.json.minisig
 mach-index.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-index.json
-index.json.minisig
+zig-index.json
+zig-index.json.minisig
+mach-index.json
 sources.old.json
 sources.new.json
+
+.direnv
+result

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3298+6fe1993d8.tar.xz",
-        "version": "0.14.0-dev.3298+6fe1993d8",
-        "sha256": "845c1f174f818d8f7762509ec24634cfa664d733a4ebdac68320e080643c36f4"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "version": "0.14.0-dev.3328+b6a1fdd3f",
+        "sha256": "6af6988a2c468ee4e0a2171e87c0136ff9abb05ccafa64ec791070d98af05e4e"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3298+6fe1993d8.tar.xz",
-        "version": "0.14.0-dev.3298+6fe1993d8",
-        "sha256": "fca9e9933f6989cc3a86911461a903ae9dcd12984cd1d56625a807c7fc3ad2c6"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "version": "0.14.0-dev.3328+b6a1fdd3f",
+        "sha256": "0b04b94c3ba6ec5989e3f66e0cde545aa876ba8aab56f97ace7f30cf4dbcd3b2"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3298+6fe1993d8.tar.xz",
-        "version": "0.14.0-dev.3298+6fe1993d8",
-        "sha256": "eda628284e8cd0ce10e71ba36dfb671dbb0c8e6c5db3c710efec3940f1ed3d2b"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "version": "0.14.0-dev.3328+b6a1fdd3f",
+        "sha256": "752e9243b15c9efe5e00604738af75adcb0ebe0d38b29ff5356ee1cf35d86a66"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3298+6fe1993d8.tar.xz",
-        "version": "0.14.0-dev.3298+6fe1993d8",
-        "sha256": "324a885c6538c0baf62d553dcb7488c80f4896bdbf8dc3e1350ca08dba215487"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "version": "0.14.0-dev.3328+b6a1fdd3f",
+        "sha256": "308432a18caa95ca4ee05440660acb352452be28e9df49b6ad3db945f73c8d86"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3298+6fe1993d8.zip",
-        "sha256": "0cd06574067f005b5a706ee136794a30a10e1b1655b4250397c66c17cf907e78",
-        "version": "0.14.0-dev.3298+6fe1993d8"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3328+b6a1fdd3f.zip",
+        "sha256": "4bf786bab9df985cf65f85cfc504778b2646855045ae02570d53203db78f5ef7",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3298+6fe1993d8.zip",
-        "sha256": "698ef35d6afba086759f50ad2640a9358c8ef1898848adeb9cc21f352d3728f2",
-        "version": "0.14.0-dev.3298+6fe1993d8"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3328+b6a1fdd3f.zip",
+        "sha256": "46b738fa7b1b1b98c93673483de78a491c8f12fef8c2daa628d5eb4df6fdc6ad",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
       }
     },
     "2021-02-20": {
@@ -23063,6 +23063,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3298+6fe1993d8.zip",
         "sha256": "698ef35d6afba086759f50ad2640a9358c8ef1898848adeb9cc21f352d3728f2",
         "version": "0.14.0-dev.3298+6fe1993d8"
+      }
+    },
+    "2025-02-24": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "sha256": "752e9243b15c9efe5e00604738af75adcb0ebe0d38b29ff5356ee1cf35d86a66",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "sha256": "308432a18caa95ca4ee05440660acb352452be28e9df49b6ad3db945f73c8d86",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "sha256": "6af6988a2c468ee4e0a2171e87c0136ff9abb05ccafa64ec791070d98af05e4e",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
+        "sha256": "0b04b94c3ba6ec5989e3f66e0cde545aa876ba8aab56f97ace7f30cf4dbcd3b2",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3328+b6a1fdd3f.zip",
+        "sha256": "4bf786bab9df985cf65f85cfc504778b2646855045ae02570d53203db78f5ef7",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3328+b6a1fdd3f.zip",
+        "sha256": "46b738fa7b1b1b98c93673483de78a491c8f12fef8c2daa628d5eb4df6fdc6ad",
+        "version": "0.14.0-dev.3328+b6a1fdd3f"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3267+59dc15fa0.tar.xz",
-        "version": "0.14.0-dev.3267+59dc15fa0",
-        "sha256": "31d00cb8a9b2f60f9bc065a2c3d79732843b33ce51b5b05e30a4d512555a0924"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "version": "0.14.0-dev.3271+bd237bced",
+        "sha256": "cf86eb71a626fd61a01a5d2a686a5582690ae4e474e880c9b0336dd1fc78de82"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3267+59dc15fa0.tar.xz",
-        "version": "0.14.0-dev.3267+59dc15fa0",
-        "sha256": "94d64ab2676478ff90485d37bb2e829a8e009633a5ffd705b8234f4c88efe43c"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "version": "0.14.0-dev.3271+bd237bced",
+        "sha256": "8749cb2a93d25b40821b730828c1d7e7e5a00a9e4bdee604c3852ba9b82dd5c6"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3267+59dc15fa0.tar.xz",
-        "version": "0.14.0-dev.3267+59dc15fa0",
-        "sha256": "7239342c31ab94457eab70ff72486b2e5efaacbb2b652a31aeb9a2a3759eaaa0"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "version": "0.14.0-dev.3271+bd237bced",
+        "sha256": "a6eefda5b92fe1a0d8d26b939ab4bc5972a7718acb3e9869c8f5b39989685881"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3267+59dc15fa0.tar.xz",
-        "version": "0.14.0-dev.3267+59dc15fa0",
-        "sha256": "8b18573bb9a635ad66172e04be78433bac0ce0dfb21bd05906b00bc90e1ef40f"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "version": "0.14.0-dev.3271+bd237bced",
+        "sha256": "3a4a9f3a30827f18fbc76bb128259d5d11cf1204717bdb2d2d14a5c78336b26d"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3267+59dc15fa0.zip",
-        "sha256": "6c9855c24e19bcc984970521b7e037bc02145980bfa85921492e6c1dc067ceab",
-        "version": "0.14.0-dev.3267+59dc15fa0"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3271+bd237bced.zip",
+        "sha256": "3cce380467712e453c277c93bf57470a871998a3304817da860a6aad0ee06181",
+        "version": "0.14.0-dev.3271+bd237bced"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3267+59dc15fa0.zip",
-        "sha256": "95a9e0824561a521411f70149ee7f47e211ce2ac8341ffec4b6478fa2a4df5aa",
-        "version": "0.14.0-dev.3267+59dc15fa0"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3271+bd237bced.zip",
+        "sha256": "9a8d042ec7db024db002bf8646769b196f6e1c642cc0d77cee3135d7c9a0e332",
+        "version": "0.14.0-dev.3271+bd237bced"
       }
     },
     "2021-02-20": {
@@ -22935,6 +22935,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3267+59dc15fa0.zip",
         "sha256": "95a9e0824561a521411f70149ee7f47e211ce2ac8341ffec4b6478fa2a4df5aa",
         "version": "0.14.0-dev.3267+59dc15fa0"
+      }
+    },
+    "2025-02-20": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "sha256": "a6eefda5b92fe1a0d8d26b939ab4bc5972a7718acb3e9869c8f5b39989685881",
+        "version": "0.14.0-dev.3271+bd237bced"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "sha256": "3a4a9f3a30827f18fbc76bb128259d5d11cf1204717bdb2d2d14a5c78336b26d",
+        "version": "0.14.0-dev.3271+bd237bced"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "sha256": "cf86eb71a626fd61a01a5d2a686a5582690ae4e474e880c9b0336dd1fc78de82",
+        "version": "0.14.0-dev.3271+bd237bced"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3271+bd237bced.tar.xz",
+        "sha256": "8749cb2a93d25b40821b730828c1d7e7e5a00a9e4bdee604c3852ba9b82dd5c6",
+        "version": "0.14.0-dev.3271+bd237bced"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3271+bd237bced.zip",
+        "sha256": "3cce380467712e453c277c93bf57470a871998a3304817da860a6aad0ee06181",
+        "version": "0.14.0-dev.3271+bd237bced"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3271+bd237bced.zip",
+        "sha256": "9a8d042ec7db024db002bf8646769b196f6e1c642cc0d77cee3135d7c9a0e332",
+        "version": "0.14.0-dev.3271+bd237bced"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "version": "0.14.0-dev.3286+05d8b565a",
-        "sha256": "5293449f628e82a47067ec2711d299086d83d0459418a1cdee7a26173b08f1ee"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "version": "0.14.0-dev.3296+a7467b9bb",
+        "sha256": "ed6e0fc5981fae9703553f31c6cedc90e17ed7d83f4b0b755f332b61218384bc"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "version": "0.14.0-dev.3286+05d8b565a",
-        "sha256": "4f5551a4fc91de5f7dca13eaba2da0b57919c5099d80b7babe906af6320638e0"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "version": "0.14.0-dev.3296+a7467b9bb",
+        "sha256": "40407be0371ebaf757740cc8bc6eb84676245440b87f6297b0dcffe5703315ce"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "version": "0.14.0-dev.3286+05d8b565a",
-        "sha256": "264384888a1a6b0bd84a435281f9afbcdd99e4bf5bb909037457ebea1bfd76ce"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "version": "0.14.0-dev.3296+a7467b9bb",
+        "sha256": "1b3478970cabdbaba023b5c105d9229343f7611abd192888621f42f789a43471"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "version": "0.14.0-dev.3286+05d8b565a",
-        "sha256": "8ab842fa321c4f20c4adfc67aaac949b227466e1f17e005ad1df6df860c6f939"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "version": "0.14.0-dev.3296+a7467b9bb",
+        "sha256": "6105c1feda4c64fdf32a59527e5f9e070b4c4cbf0abbcf1f10cdd004b654fb32"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3286+05d8b565a.zip",
-        "sha256": "a7496a379b0c27b45b9c1bbd2bfc59cf41005175532f4eafc09a1ea6628c70ce",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3296+a7467b9bb.zip",
+        "sha256": "ac800596f2475c2a53d7f53e8e0d03a3d6c42ac0cd8edef6b275958cb3d2aa3a",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3286+05d8b565a.zip",
-        "sha256": "bba104ce7365a5d7ee6a31da081e3440008f6fad9a073a1a11dce9e2f1ba7e23",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3296+a7467b9bb.zip",
+        "sha256": "451d36b8d4f99c874c30cadbcbd8d4d99f395df2f1b0325ec7dcf1307bd18ec7",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       }
     },
     "2021-02-20": {
@@ -23003,34 +23003,34 @@
     },
     "2025-02-22": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "sha256": "264384888a1a6b0bd84a435281f9afbcdd99e4bf5bb909037457ebea1bfd76ce",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "sha256": "1b3478970cabdbaba023b5c105d9229343f7611abd192888621f42f789a43471",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "sha256": "8ab842fa321c4f20c4adfc67aaac949b227466e1f17e005ad1df6df860c6f939",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "sha256": "6105c1feda4c64fdf32a59527e5f9e070b4c4cbf0abbcf1f10cdd004b654fb32",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "sha256": "5293449f628e82a47067ec2711d299086d83d0459418a1cdee7a26173b08f1ee",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "sha256": "ed6e0fc5981fae9703553f31c6cedc90e17ed7d83f4b0b755f332b61218384bc",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
-        "sha256": "4f5551a4fc91de5f7dca13eaba2da0b57919c5099d80b7babe906af6320638e0",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3296+a7467b9bb.tar.xz",
+        "sha256": "40407be0371ebaf757740cc8bc6eb84676245440b87f6297b0dcffe5703315ce",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3286+05d8b565a.zip",
-        "sha256": "a7496a379b0c27b45b9c1bbd2bfc59cf41005175532f4eafc09a1ea6628c70ce",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3296+a7467b9bb.zip",
+        "sha256": "ac800596f2475c2a53d7f53e8e0d03a3d6c42ac0cd8edef6b275958cb3d2aa3a",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3286+05d8b565a.zip",
-        "sha256": "bba104ce7365a5d7ee6a31da081e3440008f6fad9a073a1a11dce9e2f1ba7e23",
-        "version": "0.14.0-dev.3286+05d8b565a"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3296+a7467b9bb.zip",
+        "sha256": "451d36b8d4f99c874c30cadbcbd8d4d99f395df2f1b0325ec7dcf1307bd18ec7",
+        "version": "0.14.0-dev.3296+a7467b9bb"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0.tar.xz",
-        "version": "0.14.0",
-        "sha256": "d731dc81e1dff2d5f9b1d1979d554648df6d05f7723d1cc9e37430c7ca88d573"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.10+214750fcf.tar.xz",
+        "version": "0.15.0-dev.10+214750fcf",
+        "sha256": "a5e3ddf774e3f08afe5f68b54ab704a5e0d0da45867a4e4d43cb494dc19ed5d4"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0.tar.xz",
-        "version": "0.14.0",
-        "sha256": "d387b2dc29e4a078dc1d7969e0e8d58e96da1a9ba4cbb15c56297b414138bed0"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.10+214750fcf.tar.xz",
+        "version": "0.15.0-dev.10+214750fcf",
+        "sha256": "649e3b12cf7d77b0b444b9c4bb0c4df77cbc4b10b5ad6a0ca8320581538ef318"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0.tar.xz",
-        "version": "0.14.0",
-        "sha256": "d8bca68733720c3352b5204783880fb7bb6df573d8e5846c974d4d6e98a1fce7"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.10+214750fcf.tar.xz",
+        "version": "0.15.0-dev.10+214750fcf",
+        "sha256": "7347a6e444f5bd83243077af310358d654a20ed305c022fd1d36d8284c1a8301"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0.tar.xz",
-        "version": "0.14.0",
-        "sha256": "860028deb178f8dc809135d51a52f30e5d3e645650a86fbbe3a8a12d73fe5486"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.10+214750fcf.tar.xz",
+        "version": "0.15.0-dev.10+214750fcf",
+        "sha256": "3c949309a2fc68cf1f26aea88a6544ed64efcd032547973e4e12bf7ab4dba1b0"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0.zip",
-        "sha256": "ac331b5a18dc3d3b301ec658a9532f24de1fd350197e0f34caa559437eb8d022",
-        "version": "0.14.0"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.10+214750fcf.zip",
+        "sha256": "37c27964350ca4dcb0819632facccb00146b4faea79122fed7a1d1c8b8efce7f",
+        "version": "0.15.0-dev.10+214750fcf"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0.zip",
-        "sha256": "7921e2696d5bd3741b2a1ef02b7126e59d90e32a267fece13669fb05b5e47f8c",
-        "version": "0.14.0"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.10+214750fcf.zip",
+        "sha256": "1635ab8591ff49a0c12042fb86bf24b567d4dc94213f3671617870883243e845",
+        "version": "0.15.0-dev.10+214750fcf"
       }
     },
     "2021-02-20": {
@@ -23416,6 +23416,38 @@
         "sha256": "7921e2696d5bd3741b2a1ef02b7126e59d90e32a267fece13669fb05b5e47f8c",
         "version": "0.14.0"
       }
+    },
+    "2025-03-08": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.10+214750fcf.tar.xz",
+        "sha256": "7347a6e444f5bd83243077af310358d654a20ed305c022fd1d36d8284c1a8301",
+        "version": "0.15.0-dev.10+214750fcf"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.10+214750fcf.tar.xz",
+        "sha256": "3c949309a2fc68cf1f26aea88a6544ed64efcd032547973e4e12bf7ab4dba1b0",
+        "version": "0.15.0-dev.10+214750fcf"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.10+214750fcf.tar.xz",
+        "sha256": "a5e3ddf774e3f08afe5f68b54ab704a5e0d0da45867a4e4d43cb494dc19ed5d4",
+        "version": "0.15.0-dev.10+214750fcf"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.10+214750fcf.tar.xz",
+        "sha256": "649e3b12cf7d77b0b444b9c4bb0c4df77cbc4b10b5ad6a0ca8320581538ef318",
+        "version": "0.15.0-dev.10+214750fcf"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.10+214750fcf.zip",
+        "sha256": "37c27964350ca4dcb0819632facccb00146b4faea79122fed7a1d1c8b8efce7f",
+        "version": "0.15.0-dev.10+214750fcf"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.10+214750fcf.zip",
+        "sha256": "1635ab8591ff49a0c12042fb86bf24b567d4dc94213f3671617870883243e845",
+        "version": "0.15.0-dev.10+214750fcf"
+      }
     }
   },
   "0.7.1": {
@@ -23946,32 +23978,32 @@
   },
   "0.14.0": {
     "x86_64-darwin": {
-      "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0.tar.xz",
+      "url": "https://ziglang.org/download/0.14.0/zig-macos-x86_64-0.14.0.tar.xz",
       "sha256": "685816166f21f0b8d6fc7aa6a36e91396dcd82ca6556dfbe3e329deffc01fec3",
       "version": "0.14.0"
     },
     "aarch64-darwin": {
-      "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0.tar.xz",
+      "url": "https://ziglang.org/download/0.14.0/zig-macos-aarch64-0.14.0.tar.xz",
       "sha256": "b71e4b7c4b4be9953657877f7f9e6f7ee89114c716da7c070f4a238220e95d7e",
       "version": "0.14.0"
     },
     "x86_64-linux": {
-      "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0.tar.xz",
+      "url": "https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz",
       "sha256": "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982",
       "version": "0.14.0"
     },
     "aarch64-linux": {
-      "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0.tar.xz",
+      "url": "https://ziglang.org/download/0.14.0/zig-linux-aarch64-0.14.0.tar.xz",
       "sha256": "ab64e3ea277f6fc5f3d723dcd95d9ce1ab282c8ed0f431b4de880d30df891e4f",
       "version": "0.14.0"
     },
     "x86_64-windows": {
-      "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0.zip",
+      "url": "https://ziglang.org/download/0.14.0/zig-windows-x86_64-0.14.0.zip",
       "sha256": "f53e5f9011ba20bbc3e0e6d0a9441b31eb227a97bac0e7d24172f1b8b27b4371",
       "version": "0.14.0"
     },
     "aarch64-windows": {
-      "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0.zip",
+      "url": "https://ziglang.org/download/0.14.0/zig-windows-aarch64-0.14.0.zip",
       "sha256": "03e984383ebb8f85293557cfa9f48ee8698e7c400239570c9ff1aef3bffaf046",
       "version": "0.14.0"
     }

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "version": "0.14.0-dev.3224+5ab511307",
-        "sha256": "80667941010ee58b4102d19df35dc5c917d4bdf06ccf91a72b67d8b47fb90bb8"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "version": "0.14.0-dev.3237+ddff1fa4c",
+        "sha256": "07f750842b74e4c59113a74e6da0b0f266900de8b389789f2ab8ded610db2470"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "version": "0.14.0-dev.3224+5ab511307",
-        "sha256": "8be2709d353e14bf2688c57512c7a6491d155d88e1562fec3a032caf5d428d7b"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "version": "0.14.0-dev.3237+ddff1fa4c",
+        "sha256": "3804bb9d7d41ff47df8c68f22fb0a63390a8b8d7af97d44a4163f2669a593446"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "version": "0.14.0-dev.3224+5ab511307",
-        "sha256": "82f869c7a7b518b20d37dac7c8d2321232865699cb351427fa8d0fdf6eccb01b"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "version": "0.14.0-dev.3237+ddff1fa4c",
+        "sha256": "ff069db5d5ffe5bf833d7b03aae974014781317c64ff22e8a736465746d5c608"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "version": "0.14.0-dev.3224+5ab511307",
-        "sha256": "a7c684b5d68fbf56345e83bfeb4f588ff61992abcb8db78b8a05038204c036ab"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "version": "0.14.0-dev.3237+ddff1fa4c",
+        "sha256": "bd45662c7db43bf996233c6a1b314666eb9423128fe7c950d75936eb4a4c1e6e"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3224+5ab511307.zip",
-        "sha256": "82bcf4c001cfc8b02c43da89902f0e0080852ac02b4b045622b261d368d6f368",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3237+ddff1fa4c.zip",
+        "sha256": "b73e71735026fe2377bee85153693246138c80b63b0f3ff1fab330069b1aa4c6",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3224+5ab511307.zip",
-        "sha256": "a63281acc32e8829c3a1dd921e6f71fcf057011b0487ff602bab95eae21f06f5",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3237+ddff1fa4c.zip",
+        "sha256": "0d73391698fe432d4ee516090aa37bbc2f463cc2317990c862d337bab4f4fc7d",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       }
     },
     "2021-02-20": {
@@ -22811,34 +22811,34 @@
     },
     "2025-02-16": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "sha256": "82f869c7a7b518b20d37dac7c8d2321232865699cb351427fa8d0fdf6eccb01b",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "sha256": "ff069db5d5ffe5bf833d7b03aae974014781317c64ff22e8a736465746d5c608",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "sha256": "a7c684b5d68fbf56345e83bfeb4f588ff61992abcb8db78b8a05038204c036ab",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "sha256": "bd45662c7db43bf996233c6a1b314666eb9423128fe7c950d75936eb4a4c1e6e",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "sha256": "80667941010ee58b4102d19df35dc5c917d4bdf06ccf91a72b67d8b47fb90bb8",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "sha256": "07f750842b74e4c59113a74e6da0b0f266900de8b389789f2ab8ded610db2470",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
-        "sha256": "8be2709d353e14bf2688c57512c7a6491d155d88e1562fec3a032caf5d428d7b",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
+        "sha256": "3804bb9d7d41ff47df8c68f22fb0a63390a8b8d7af97d44a4163f2669a593446",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3224+5ab511307.zip",
-        "sha256": "82bcf4c001cfc8b02c43da89902f0e0080852ac02b4b045622b261d368d6f368",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3237+ddff1fa4c.zip",
+        "sha256": "b73e71735026fe2377bee85153693246138c80b63b0f3ff1fab330069b1aa4c6",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3224+5ab511307.zip",
-        "sha256": "a63281acc32e8829c3a1dd921e6f71fcf057011b0487ff602bab95eae21f06f5",
-        "version": "0.14.0-dev.3224+5ab511307"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3237+ddff1fa4c.zip",
+        "sha256": "0d73391698fe432d4ee516090aa37bbc2f463cc2317990c862d337bab4f4fc7d",
+        "version": "0.14.0-dev.3237+ddff1fa4c"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "version": "0.15.0-dev.203+84c9cee50",
-        "sha256": "e9178061022d73667803b7d98bf8ce538870fb44fc6be6a58edbb3b18c992df7"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "version": "0.15.0-dev.208+8acedfd5b",
+        "sha256": "af7903e257e31693052aeca20b8fefcc3cf22ca2a39b6f2cacf7f19262896db6"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "version": "0.15.0-dev.203+84c9cee50",
-        "sha256": "be9dc5ab99b4457bdbfdab68430089b0011747a783607512a79f6d6adbaf8c0b"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "version": "0.15.0-dev.208+8acedfd5b",
+        "sha256": "8ed628d03398ea0d20e8a96896de929cfb66f00c0b273c04b2fc4158c08a23ef"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "version": "0.15.0-dev.203+84c9cee50",
-        "sha256": "e397a249ff7c8da5efe5b8ca71a7e0a073ea419b908c155622f733ce066bafea"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "version": "0.15.0-dev.208+8acedfd5b",
+        "sha256": "8f79a0bf8ca06cdb9a66f7b4ad252d7bd5e35e6a48b687ea321df847a4e4e422"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "version": "0.15.0-dev.203+84c9cee50",
-        "sha256": "acfe49afb0f2b90b9491cf85e5b7b90d366268cb6e750c264babaede21b0eac1"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "version": "0.15.0-dev.208+8acedfd5b",
+        "sha256": "d46f997363bc6437c0d389f7f05f922072adc50f45b9ce67a0015d54695499a4"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.203+84c9cee50.zip",
-        "sha256": "a84847e701479746b30e96df9696f35f24e47a3b267974d80a358e322d02b1fd",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.208+8acedfd5b.zip",
+        "sha256": "2f8dbbd52331ba12b80b9688d0fc616c02c47c169d3bef5044fad07ebb9811ae",
+        "version": "0.15.0-dev.208+8acedfd5b"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.203+84c9cee50.zip",
-        "sha256": "e9908d46e1f782edda2b5b0e3f147003d17a26f014c278a301e3cd67ee5c3969",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.208+8acedfd5b.zip",
+        "sha256": "da86aec0b5d249a701f259a5f5cb76e7497454656d07f7a3790810b42bac829e",
+        "version": "0.15.0-dev.208+8acedfd5b"
       }
     },
     "2021-02-20": {
@@ -24123,34 +24123,34 @@
     },
     "2025-04-05": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "sha256": "e397a249ff7c8da5efe5b8ca71a7e0a073ea419b908c155622f733ce066bafea",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "sha256": "8f79a0bf8ca06cdb9a66f7b4ad252d7bd5e35e6a48b687ea321df847a4e4e422",
+        "version": "0.15.0-dev.208+8acedfd5b"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "sha256": "acfe49afb0f2b90b9491cf85e5b7b90d366268cb6e750c264babaede21b0eac1",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "sha256": "d46f997363bc6437c0d389f7f05f922072adc50f45b9ce67a0015d54695499a4",
+        "version": "0.15.0-dev.208+8acedfd5b"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "sha256": "e9178061022d73667803b7d98bf8ce538870fb44fc6be6a58edbb3b18c992df7",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "sha256": "af7903e257e31693052aeca20b8fefcc3cf22ca2a39b6f2cacf7f19262896db6",
+        "version": "0.15.0-dev.208+8acedfd5b"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
-        "sha256": "be9dc5ab99b4457bdbfdab68430089b0011747a783607512a79f6d6adbaf8c0b",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.208+8acedfd5b.tar.xz",
+        "sha256": "8ed628d03398ea0d20e8a96896de929cfb66f00c0b273c04b2fc4158c08a23ef",
+        "version": "0.15.0-dev.208+8acedfd5b"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.203+84c9cee50.zip",
-        "sha256": "a84847e701479746b30e96df9696f35f24e47a3b267974d80a358e322d02b1fd",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.208+8acedfd5b.zip",
+        "sha256": "2f8dbbd52331ba12b80b9688d0fc616c02c47c169d3bef5044fad07ebb9811ae",
+        "version": "0.15.0-dev.208+8acedfd5b"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.203+84c9cee50.zip",
-        "sha256": "e9908d46e1f782edda2b5b0e3f147003d17a26f014c278a301e3cd67ee5c3969",
-        "version": "0.15.0-dev.203+84c9cee50"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.208+8acedfd5b.zip",
+        "sha256": "da86aec0b5d249a701f259a5f5cb76e7497454656d07f7a3790810b42bac829e",
+        "version": "0.15.0-dev.208+8acedfd5b"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
-        "version": "0.14.0-dev.3237+ddff1fa4c",
-        "sha256": "07f750842b74e4c59113a74e6da0b0f266900de8b389789f2ab8ded610db2470"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "version": "0.14.0-dev.3239+d7b93c787",
+        "sha256": "31a0f3bddc31e6e80309a869e5d034e4dca6d065e7c157dd7ffc572960a6173f"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
-        "version": "0.14.0-dev.3237+ddff1fa4c",
-        "sha256": "3804bb9d7d41ff47df8c68f22fb0a63390a8b8d7af97d44a4163f2669a593446"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "version": "0.14.0-dev.3239+d7b93c787",
+        "sha256": "bfa4ffef66c01016a0704dc6e0bbd6212d802e59f2a879a1fdf415615dae5607"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
-        "version": "0.14.0-dev.3237+ddff1fa4c",
-        "sha256": "ff069db5d5ffe5bf833d7b03aae974014781317c64ff22e8a736465746d5c608"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "version": "0.14.0-dev.3239+d7b93c787",
+        "sha256": "55441118e3d99ff36eb7d5f9a161eae95b98c0134961722b30855fb88db7836a"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3237+ddff1fa4c.tar.xz",
-        "version": "0.14.0-dev.3237+ddff1fa4c",
-        "sha256": "bd45662c7db43bf996233c6a1b314666eb9423128fe7c950d75936eb4a4c1e6e"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "version": "0.14.0-dev.3239+d7b93c787",
+        "sha256": "09da7005a877c6eebe3a5a579ce1bfa00ebf1cc3fa5f7e49f8162a17402bc3eb"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3237+ddff1fa4c.zip",
-        "sha256": "b73e71735026fe2377bee85153693246138c80b63b0f3ff1fab330069b1aa4c6",
-        "version": "0.14.0-dev.3237+ddff1fa4c"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3239+d7b93c787.zip",
+        "sha256": "2ccba9152152eac42f7beea139dd1eb5844a6af94fc963acc4282a5e4dcc2c70",
+        "version": "0.14.0-dev.3239+d7b93c787"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3237+ddff1fa4c.zip",
-        "sha256": "0d73391698fe432d4ee516090aa37bbc2f463cc2317990c862d337bab4f4fc7d",
-        "version": "0.14.0-dev.3237+ddff1fa4c"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3239+d7b93c787.zip",
+        "sha256": "4f1b8e64307921747b3c1539cac98d29713716a4ff873f9248d78ca826a8c856",
+        "version": "0.14.0-dev.3239+d7b93c787"
       }
     },
     "2021-02-20": {
@@ -22839,6 +22839,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3237+ddff1fa4c.zip",
         "sha256": "0d73391698fe432d4ee516090aa37bbc2f463cc2317990c862d337bab4f4fc7d",
         "version": "0.14.0-dev.3237+ddff1fa4c"
+      }
+    },
+    "2025-02-17": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "sha256": "55441118e3d99ff36eb7d5f9a161eae95b98c0134961722b30855fb88db7836a",
+        "version": "0.14.0-dev.3239+d7b93c787"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "sha256": "09da7005a877c6eebe3a5a579ce1bfa00ebf1cc3fa5f7e49f8162a17402bc3eb",
+        "version": "0.14.0-dev.3239+d7b93c787"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "sha256": "31a0f3bddc31e6e80309a869e5d034e4dca6d065e7c157dd7ffc572960a6173f",
+        "version": "0.14.0-dev.3239+d7b93c787"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3239+d7b93c787.tar.xz",
+        "sha256": "bfa4ffef66c01016a0704dc6e0bbd6212d802e59f2a879a1fdf415615dae5607",
+        "version": "0.14.0-dev.3239+d7b93c787"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3239+d7b93c787.zip",
+        "sha256": "2ccba9152152eac42f7beea139dd1eb5844a6af94fc963acc4282a5e4dcc2c70",
+        "version": "0.14.0-dev.3239+d7b93c787"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3239+d7b93c787.zip",
+        "sha256": "4f1b8e64307921747b3c1539cac98d29713716a4ff873f9248d78ca826a8c856",
+        "version": "0.14.0-dev.3239+d7b93c787"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3367+1cc388d52.tar.xz",
-        "version": "0.14.0-dev.3367+1cc388d52",
-        "sha256": "5cfcdc3304299c29f3f2566742cacbf128973fbee719886e723ab9416f3a11a2"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3385+055969b10.tar.xz",
+        "version": "0.14.0-dev.3385+055969b10",
+        "sha256": "fa8c7e54993d706bcc4fa392fdf5d2d771c41f960a7df9ea8f8a0f82a4ca6759"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3367+1cc388d52.tar.xz",
-        "version": "0.14.0-dev.3367+1cc388d52",
-        "sha256": "1fa99348b32fde05e3ce7a52c0775bb55065d5367d6b3d8bed083164a3d5836b"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3385+055969b10.tar.xz",
+        "version": "0.14.0-dev.3385+055969b10",
+        "sha256": "69fba5990f86b4afc07f24c1f6641e48adb6537a5c6c221f3be24da489d0493d"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3367+1cc388d52.tar.xz",
-        "version": "0.14.0-dev.3367+1cc388d52",
-        "sha256": "31fb50870e9db689c15401f481aeb607d4822d654f29ee273fe247f0e7989609"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3385+055969b10.tar.xz",
+        "version": "0.14.0-dev.3385+055969b10",
+        "sha256": "a008b0ab2bfb716dab2311f98d8009122d422d2c69128e92b54dba52fe8220f9"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3367+1cc388d52.tar.xz",
-        "version": "0.14.0-dev.3367+1cc388d52",
-        "sha256": "883df3add2687bd518a00bd268a01ba1dac2db2cb485fddfa3c3fd7ae033bdba"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3385+055969b10.tar.xz",
+        "version": "0.14.0-dev.3385+055969b10",
+        "sha256": "e212bc077440490049de79bcbeee4cca1dd7e0bb5b569365e7e0338c0e31bec5"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3367+1cc388d52.zip",
-        "sha256": "c3263c5e86be51139eb1a4841b413fb4a0a2c0c2622dacc64edefbf2e27a5bcd",
-        "version": "0.14.0-dev.3367+1cc388d52"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3385+055969b10.zip",
+        "sha256": "9a8f7bfbf164a6c66bf523105120b3cc86808a11dbbbe7bc33e66f21a2433fff",
+        "version": "0.14.0-dev.3385+055969b10"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3367+1cc388d52.zip",
-        "sha256": "fc1db213eec98016d4a50a44688263f385fa4b958d35eb811c4adbf0653ecfaf",
-        "version": "0.14.0-dev.3367+1cc388d52"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3385+055969b10.zip",
+        "sha256": "498ce1501f067658d1cd663e15126320c101a3d11d01ef12aa6b3e9e4e3fcc46",
+        "version": "0.14.0-dev.3385+055969b10"
       }
     },
     "2021-02-20": {
@@ -23127,6 +23127,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3367+1cc388d52.zip",
         "sha256": "fc1db213eec98016d4a50a44688263f385fa4b958d35eb811c4adbf0653ecfaf",
         "version": "0.14.0-dev.3367+1cc388d52"
+      }
+    },
+    "2025-02-26": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3385+055969b10.tar.xz",
+        "sha256": "a008b0ab2bfb716dab2311f98d8009122d422d2c69128e92b54dba52fe8220f9",
+        "version": "0.14.0-dev.3385+055969b10"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3385+055969b10.tar.xz",
+        "sha256": "e212bc077440490049de79bcbeee4cca1dd7e0bb5b569365e7e0338c0e31bec5",
+        "version": "0.14.0-dev.3385+055969b10"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3385+055969b10.tar.xz",
+        "sha256": "fa8c7e54993d706bcc4fa392fdf5d2d771c41f960a7df9ea8f8a0f82a4ca6759",
+        "version": "0.14.0-dev.3385+055969b10"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3385+055969b10.tar.xz",
+        "sha256": "69fba5990f86b4afc07f24c1f6641e48adb6537a5c6c221f3be24da489d0493d",
+        "version": "0.14.0-dev.3385+055969b10"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3385+055969b10.zip",
+        "sha256": "9a8f7bfbf164a6c66bf523105120b3cc86808a11dbbbe7bc33e66f21a2433fff",
+        "version": "0.14.0-dev.3385+055969b10"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3385+055969b10.zip",
+        "sha256": "498ce1501f067658d1cd663e15126320c101a3d11d01ef12aa6b3e9e4e3fcc46",
+        "version": "0.14.0-dev.3385+055969b10"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3296+a7467b9bb.tar.xz",
-        "version": "0.14.0-dev.3296+a7467b9bb",
-        "sha256": "ed6e0fc5981fae9703553f31c6cedc90e17ed7d83f4b0b755f332b61218384bc"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "version": "0.14.0-dev.3298+6fe1993d8",
+        "sha256": "845c1f174f818d8f7762509ec24634cfa664d733a4ebdac68320e080643c36f4"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3296+a7467b9bb.tar.xz",
-        "version": "0.14.0-dev.3296+a7467b9bb",
-        "sha256": "40407be0371ebaf757740cc8bc6eb84676245440b87f6297b0dcffe5703315ce"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "version": "0.14.0-dev.3298+6fe1993d8",
+        "sha256": "fca9e9933f6989cc3a86911461a903ae9dcd12984cd1d56625a807c7fc3ad2c6"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3296+a7467b9bb.tar.xz",
-        "version": "0.14.0-dev.3296+a7467b9bb",
-        "sha256": "1b3478970cabdbaba023b5c105d9229343f7611abd192888621f42f789a43471"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "version": "0.14.0-dev.3298+6fe1993d8",
+        "sha256": "eda628284e8cd0ce10e71ba36dfb671dbb0c8e6c5db3c710efec3940f1ed3d2b"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3296+a7467b9bb.tar.xz",
-        "version": "0.14.0-dev.3296+a7467b9bb",
-        "sha256": "6105c1feda4c64fdf32a59527e5f9e070b4c4cbf0abbcf1f10cdd004b654fb32"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "version": "0.14.0-dev.3298+6fe1993d8",
+        "sha256": "324a885c6538c0baf62d553dcb7488c80f4896bdbf8dc3e1350ca08dba215487"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3296+a7467b9bb.zip",
-        "sha256": "ac800596f2475c2a53d7f53e8e0d03a3d6c42ac0cd8edef6b275958cb3d2aa3a",
-        "version": "0.14.0-dev.3296+a7467b9bb"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3298+6fe1993d8.zip",
+        "sha256": "0cd06574067f005b5a706ee136794a30a10e1b1655b4250397c66c17cf907e78",
+        "version": "0.14.0-dev.3298+6fe1993d8"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3296+a7467b9bb.zip",
-        "sha256": "451d36b8d4f99c874c30cadbcbd8d4d99f395df2f1b0325ec7dcf1307bd18ec7",
-        "version": "0.14.0-dev.3296+a7467b9bb"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3298+6fe1993d8.zip",
+        "sha256": "698ef35d6afba086759f50ad2640a9358c8ef1898848adeb9cc21f352d3728f2",
+        "version": "0.14.0-dev.3298+6fe1993d8"
       }
     },
     "2021-02-20": {
@@ -23031,6 +23031,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3296+a7467b9bb.zip",
         "sha256": "451d36b8d4f99c874c30cadbcbd8d4d99f395df2f1b0325ec7dcf1307bd18ec7",
         "version": "0.14.0-dev.3296+a7467b9bb"
+      }
+    },
+    "2025-02-23": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "sha256": "eda628284e8cd0ce10e71ba36dfb671dbb0c8e6c5db3c710efec3940f1ed3d2b",
+        "version": "0.14.0-dev.3298+6fe1993d8"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "sha256": "324a885c6538c0baf62d553dcb7488c80f4896bdbf8dc3e1350ca08dba215487",
+        "version": "0.14.0-dev.3298+6fe1993d8"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "sha256": "845c1f174f818d8f7762509ec24634cfa664d733a4ebdac68320e080643c36f4",
+        "version": "0.14.0-dev.3298+6fe1993d8"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3298+6fe1993d8.tar.xz",
+        "sha256": "fca9e9933f6989cc3a86911461a903ae9dcd12984cd1d56625a807c7fc3ad2c6",
+        "version": "0.14.0-dev.3298+6fe1993d8"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3298+6fe1993d8.zip",
+        "sha256": "0cd06574067f005b5a706ee136794a30a10e1b1655b4250397c66c17cf907e78",
+        "version": "0.14.0-dev.3298+6fe1993d8"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3298+6fe1993d8.zip",
+        "sha256": "698ef35d6afba086759f50ad2640a9358c8ef1898848adeb9cc21f352d3728f2",
+        "version": "0.14.0-dev.3298+6fe1993d8"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.23+1eb729b9b.tar.xz",
-        "version": "0.15.0-dev.23+1eb729b9b",
-        "sha256": "750d6683c2a5de609bfc85966f3e8ba66f0421f8986cd86dab54e99bf363e01d"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
+        "version": "0.15.0-dev.33+539f3effd",
+        "sha256": "8b02d2a7b749a8df1cae5d7091b0ba20028c9c91d32a9c291ad833e191f5fdc2"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.23+1eb729b9b.tar.xz",
-        "version": "0.15.0-dev.23+1eb729b9b",
-        "sha256": "2eb78418e16b3bad09fd8a752cdfb72604d00741121ee71a9dd496e3b90baf83"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
+        "version": "0.15.0-dev.33+539f3effd",
+        "sha256": "04d5152d4362f160ad87fd59f1c6b5f14c1f21c7145da62729663c05814c2df0"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.23+1eb729b9b.tar.xz",
-        "version": "0.15.0-dev.23+1eb729b9b",
-        "sha256": "572fddccb1a5d045a2039f57e831eeacd8cbc328630987087b38c0c16197f89c"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
+        "version": "0.15.0-dev.33+539f3effd",
+        "sha256": "f9022398a154469bc972fc2e164276a1d502c08a747468f610c7add3a069c452"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.23+1eb729b9b.tar.xz",
-        "version": "0.15.0-dev.23+1eb729b9b",
-        "sha256": "bdf1faa1740299e5051d26561fa229a45576bf5d9586e8afbbb1a1789b28169b"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
+        "version": "0.15.0-dev.33+539f3effd",
+        "sha256": "5baec025de841d62348902e5ea53630732ff87f8c78e28456258aba0fcc2db9e"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.23+1eb729b9b.zip",
-        "sha256": "e9dc2b7658adf002c77fb383860c8241ea7964b603377350c72ad94687397e0b",
-        "version": "0.15.0-dev.23+1eb729b9b"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.33+539f3effd.zip",
+        "sha256": "415dd796c0370fabb92a0ae653029897442fe187931adef17b2ae570008d8365",
+        "version": "0.15.0-dev.33+539f3effd"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.23+1eb729b9b.zip",
-        "sha256": "692404aad186cf2c44b045dbf68a91d77c0cf6b8aa0bd0f0ad4931f38fe09049",
-        "version": "0.15.0-dev.23+1eb729b9b"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.33+539f3effd.zip",
+        "sha256": "5c0771bc97949cbb5221ae2a27c93ff5b08d43f42c495a5d26f1f25dd0acf4d6",
+        "version": "0.15.0-dev.33+539f3effd"
       }
     },
     "2021-02-20": {
@@ -23479,6 +23479,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.23+1eb729b9b.zip",
         "sha256": "692404aad186cf2c44b045dbf68a91d77c0cf6b8aa0bd0f0ad4931f38fe09049",
         "version": "0.15.0-dev.23+1eb729b9b"
+      }
+    },
+    "2025-03-10": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
+        "sha256": "f9022398a154469bc972fc2e164276a1d502c08a747468f610c7add3a069c452",
+        "version": "0.15.0-dev.33+539f3effd"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
+        "sha256": "5baec025de841d62348902e5ea53630732ff87f8c78e28456258aba0fcc2db9e",
+        "version": "0.15.0-dev.33+539f3effd"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
+        "sha256": "8b02d2a7b749a8df1cae5d7091b0ba20028c9c91d32a9c291ad833e191f5fdc2",
+        "version": "0.15.0-dev.33+539f3effd"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
+        "sha256": "04d5152d4362f160ad87fd59f1c6b5f14c1f21c7145da62729663c05814c2df0",
+        "version": "0.15.0-dev.33+539f3effd"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.33+539f3effd.zip",
+        "sha256": "415dd796c0370fabb92a0ae653029897442fe187931adef17b2ae570008d8365",
+        "version": "0.15.0-dev.33+539f3effd"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.33+539f3effd.zip",
+        "sha256": "5c0771bc97949cbb5221ae2a27c93ff5b08d43f42c495a5d26f1f25dd0acf4d6",
+        "version": "0.15.0-dev.33+539f3effd"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "version": "0.14.0-dev.3357+c44f4501e",
-        "sha256": "bdf171adc573a0ea3d3812f099348b364219acbc9dee198f9523c37dae4a5b3a"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "version": "0.14.0-dev.3367+1cc388d52",
+        "sha256": "5cfcdc3304299c29f3f2566742cacbf128973fbee719886e723ab9416f3a11a2"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "version": "0.14.0-dev.3357+c44f4501e",
-        "sha256": "ba8b640ff57bdbb5203bdb1d4873d56935f285ff904734ab9af0ab44d396af0c"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "version": "0.14.0-dev.3367+1cc388d52",
+        "sha256": "1fa99348b32fde05e3ce7a52c0775bb55065d5367d6b3d8bed083164a3d5836b"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "version": "0.14.0-dev.3357+c44f4501e",
-        "sha256": "377562c74475516caadb553d903669764acfe1277047b596c41151432444ef0c"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "version": "0.14.0-dev.3367+1cc388d52",
+        "sha256": "31fb50870e9db689c15401f481aeb607d4822d654f29ee273fe247f0e7989609"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "version": "0.14.0-dev.3357+c44f4501e",
-        "sha256": "3e59b7c0d3282428d48f7434966bd2d4c7e95f12daa5612d659797ba89181984"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "version": "0.14.0-dev.3367+1cc388d52",
+        "sha256": "883df3add2687bd518a00bd268a01ba1dac2db2cb485fddfa3c3fd7ae033bdba"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3357+c44f4501e.zip",
-        "sha256": "3510ae244767accb76bcccbfc82d96a541b5421587e023d7d4f6966f2b678554",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3367+1cc388d52.zip",
+        "sha256": "c3263c5e86be51139eb1a4841b413fb4a0a2c0c2622dacc64edefbf2e27a5bcd",
+        "version": "0.14.0-dev.3367+1cc388d52"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3357+c44f4501e.zip",
-        "sha256": "89a5e587bd0c5676ab67da0453e29ba757abae7240b73f003155550b44074738",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3367+1cc388d52.zip",
+        "sha256": "fc1db213eec98016d4a50a44688263f385fa4b958d35eb811c4adbf0653ecfaf",
+        "version": "0.14.0-dev.3367+1cc388d52"
       }
     },
     "2021-02-20": {
@@ -23099,34 +23099,34 @@
     },
     "2025-02-25": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "sha256": "377562c74475516caadb553d903669764acfe1277047b596c41151432444ef0c",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "sha256": "31fb50870e9db689c15401f481aeb607d4822d654f29ee273fe247f0e7989609",
+        "version": "0.14.0-dev.3367+1cc388d52"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "sha256": "3e59b7c0d3282428d48f7434966bd2d4c7e95f12daa5612d659797ba89181984",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "sha256": "883df3add2687bd518a00bd268a01ba1dac2db2cb485fddfa3c3fd7ae033bdba",
+        "version": "0.14.0-dev.3367+1cc388d52"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "sha256": "bdf171adc573a0ea3d3812f099348b364219acbc9dee198f9523c37dae4a5b3a",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "sha256": "5cfcdc3304299c29f3f2566742cacbf128973fbee719886e723ab9416f3a11a2",
+        "version": "0.14.0-dev.3367+1cc388d52"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
-        "sha256": "ba8b640ff57bdbb5203bdb1d4873d56935f285ff904734ab9af0ab44d396af0c",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3367+1cc388d52.tar.xz",
+        "sha256": "1fa99348b32fde05e3ce7a52c0775bb55065d5367d6b3d8bed083164a3d5836b",
+        "version": "0.14.0-dev.3367+1cc388d52"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3357+c44f4501e.zip",
-        "sha256": "3510ae244767accb76bcccbfc82d96a541b5421587e023d7d4f6966f2b678554",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3367+1cc388d52.zip",
+        "sha256": "c3263c5e86be51139eb1a4841b413fb4a0a2c0c2622dacc64edefbf2e27a5bcd",
+        "version": "0.14.0-dev.3367+1cc388d52"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3357+c44f4501e.zip",
-        "sha256": "89a5e587bd0c5676ab67da0453e29ba757abae7240b73f003155550b44074738",
-        "version": "0.14.0-dev.3357+c44f4501e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3367+1cc388d52.zip",
+        "sha256": "fc1db213eec98016d4a50a44688263f385fa4b958d35eb811c4adbf0653ecfaf",
+        "version": "0.14.0-dev.3367+1cc388d52"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3258+d2e70ef84.tar.xz",
-        "version": "0.14.0-dev.3258+d2e70ef84",
-        "sha256": "855fa28928a79eebb70b29595ab9952bdf3ab258ef3e266ac2e366d815936d9b"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "version": "0.14.0-dev.3259+0779e847f",
+        "sha256": "986466e257939871be62dcc5bfab027fb26d0fdeee939c7c80219a162642aab0"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3258+d2e70ef84.tar.xz",
-        "version": "0.14.0-dev.3258+d2e70ef84",
-        "sha256": "2a28fdb35d18223e03509ed7974f4b7c78a2100de4a1dde3442fe80b7eb09afa"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "version": "0.14.0-dev.3259+0779e847f",
+        "sha256": "9f96a0d61cc5d4c9e9a30a9fa46f705e8545d04955c646d2f558002c0fa5371d"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3258+d2e70ef84.tar.xz",
-        "version": "0.14.0-dev.3258+d2e70ef84",
-        "sha256": "435fcfa402cddc249e1e727a417ab1ade26c643a13222edb14b5261a64a707f7"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "version": "0.14.0-dev.3259+0779e847f",
+        "sha256": "d2200100ad252d5f1a48c8c01f2b5f734d43b74d4de00386ecaf2322a619be50"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3258+d2e70ef84.tar.xz",
-        "version": "0.14.0-dev.3258+d2e70ef84",
-        "sha256": "4a461ad310f043008b8c9b2bbf0480078d2acbc90d37418e3f4d5eb48092ea80"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "version": "0.14.0-dev.3259+0779e847f",
+        "sha256": "becf9ad5d83c17c1b607d9b5d4937a81374d41591026331c540b3eb661179ea5"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3258+d2e70ef84.zip",
-        "sha256": "87c47cba48ca80411306d91952ff68c6df3e31e56644c28ead0d730ab3ff30cb",
-        "version": "0.14.0-dev.3258+d2e70ef84"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3259+0779e847f.zip",
+        "sha256": "0ef4266393b60daae625afd285c1d1b3854a8f905a019b3aac04b94cb41c6ef8",
+        "version": "0.14.0-dev.3259+0779e847f"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3258+d2e70ef84.zip",
-        "sha256": "79569b3523783cb3a3c603dd02f01190b6b93879885cf3f176857f3efb7d91f1",
-        "version": "0.14.0-dev.3258+d2e70ef84"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3259+0779e847f.zip",
+        "sha256": "a7394a8b31ece17eed3734abc5c450a1ace100ead573c6378d121bf2d9ddf51f",
+        "version": "0.14.0-dev.3259+0779e847f"
       }
     },
     "2021-02-20": {
@@ -22903,6 +22903,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3258+d2e70ef84.zip",
         "sha256": "79569b3523783cb3a3c603dd02f01190b6b93879885cf3f176857f3efb7d91f1",
         "version": "0.14.0-dev.3258+d2e70ef84"
+      }
+    },
+    "2025-02-19": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "sha256": "d2200100ad252d5f1a48c8c01f2b5f734d43b74d4de00386ecaf2322a619be50",
+        "version": "0.14.0-dev.3259+0779e847f"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "sha256": "becf9ad5d83c17c1b607d9b5d4937a81374d41591026331c540b3eb661179ea5",
+        "version": "0.14.0-dev.3259+0779e847f"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "sha256": "986466e257939871be62dcc5bfab027fb26d0fdeee939c7c80219a162642aab0",
+        "version": "0.14.0-dev.3259+0779e847f"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
+        "sha256": "9f96a0d61cc5d4c9e9a30a9fa46f705e8545d04955c646d2f558002c0fa5371d",
+        "version": "0.14.0-dev.3259+0779e847f"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3259+0779e847f.zip",
+        "sha256": "0ef4266393b60daae625afd285c1d1b3854a8f905a019b3aac04b94cb41c6ef8",
+        "version": "0.14.0-dev.3259+0779e847f"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3259+0779e847f.zip",
+        "sha256": "a7394a8b31ece17eed3734abc5c450a1ace100ead573c6378d121bf2d9ddf51f",
+        "version": "0.14.0-dev.3259+0779e847f"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3239+d7b93c787.tar.xz",
-        "version": "0.14.0-dev.3239+d7b93c787",
-        "sha256": "31a0f3bddc31e6e80309a869e5d034e4dca6d065e7c157dd7ffc572960a6173f"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "version": "0.14.0-dev.3241+55c46870b",
+        "sha256": "5d4c941b100d7eaf29013b5ca4b5fb9c93065562aa39ac16a69ae71263c27d2f"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3239+d7b93c787.tar.xz",
-        "version": "0.14.0-dev.3239+d7b93c787",
-        "sha256": "bfa4ffef66c01016a0704dc6e0bbd6212d802e59f2a879a1fdf415615dae5607"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "version": "0.14.0-dev.3241+55c46870b",
+        "sha256": "4d9bac0eb5ddd04ba3aca15ccc0ea78fc399ea4bc591e16818e37b32ef0bc9c3"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3239+d7b93c787.tar.xz",
-        "version": "0.14.0-dev.3239+d7b93c787",
-        "sha256": "55441118e3d99ff36eb7d5f9a161eae95b98c0134961722b30855fb88db7836a"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "version": "0.14.0-dev.3241+55c46870b",
+        "sha256": "231610d0b39f35c379b7ae72848338ee454d38713de3b4040c621cbe70805177"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3239+d7b93c787.tar.xz",
-        "version": "0.14.0-dev.3239+d7b93c787",
-        "sha256": "09da7005a877c6eebe3a5a579ce1bfa00ebf1cc3fa5f7e49f8162a17402bc3eb"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "version": "0.14.0-dev.3241+55c46870b",
+        "sha256": "d34c0e18310c8478a909ceb599f04e64d5c2f738b1459d86754e7cb453980e3d"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3239+d7b93c787.zip",
-        "sha256": "2ccba9152152eac42f7beea139dd1eb5844a6af94fc963acc4282a5e4dcc2c70",
-        "version": "0.14.0-dev.3239+d7b93c787"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3241+55c46870b.zip",
+        "sha256": "26645ed33241df452708b70f5995f6df8ce38b5ad57e5eed6e790cb3db7e9665",
+        "version": "0.14.0-dev.3241+55c46870b"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3239+d7b93c787.zip",
-        "sha256": "4f1b8e64307921747b3c1539cac98d29713716a4ff873f9248d78ca826a8c856",
-        "version": "0.14.0-dev.3239+d7b93c787"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3241+55c46870b.zip",
+        "sha256": "2eee633006271122e44bc6f06886002397d1ad34b0b515e0a0de23b5b74818c7",
+        "version": "0.14.0-dev.3241+55c46870b"
       }
     },
     "2021-02-20": {
@@ -22871,6 +22871,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3239+d7b93c787.zip",
         "sha256": "4f1b8e64307921747b3c1539cac98d29713716a4ff873f9248d78ca826a8c856",
         "version": "0.14.0-dev.3239+d7b93c787"
+      }
+    },
+    "2025-02-18": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "sha256": "231610d0b39f35c379b7ae72848338ee454d38713de3b4040c621cbe70805177",
+        "version": "0.14.0-dev.3241+55c46870b"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "sha256": "d34c0e18310c8478a909ceb599f04e64d5c2f738b1459d86754e7cb453980e3d",
+        "version": "0.14.0-dev.3241+55c46870b"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "sha256": "5d4c941b100d7eaf29013b5ca4b5fb9c93065562aa39ac16a69ae71263c27d2f",
+        "version": "0.14.0-dev.3241+55c46870b"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
+        "sha256": "4d9bac0eb5ddd04ba3aca15ccc0ea78fc399ea4bc591e16818e37b32ef0bc9c3",
+        "version": "0.14.0-dev.3241+55c46870b"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3241+55c46870b.zip",
+        "sha256": "26645ed33241df452708b70f5995f6df8ce38b5ad57e5eed6e790cb3db7e9665",
+        "version": "0.14.0-dev.3241+55c46870b"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3241+55c46870b.zip",
+        "sha256": "2eee633006271122e44bc6f06886002397d1ad34b0b515e0a0de23b5b74818c7",
+        "version": "0.14.0-dev.3241+55c46870b"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.79+9f235a105.tar.xz",
-        "version": "0.15.0-dev.79+9f235a105",
-        "sha256": "538b026619216c1de99d82875a4ae83bdca59229d72e8a12b6850699465978af"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "version": "0.15.0-dev.91+98640cbeb",
+        "sha256": "686ddca588e0ffa768278413db84c11167f6196771787691e4ba6fb5fd7a88b3"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.79+9f235a105.tar.xz",
-        "version": "0.15.0-dev.79+9f235a105",
-        "sha256": "5623c2645e4c8d4d90a077daefcffdb2e48c31f29e8e2c00776da686fb311aaf"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "version": "0.15.0-dev.91+98640cbeb",
+        "sha256": "84bd895cbf75bcda78108e621a02c1e9beda54f38f7f175ab70a4376b8ff199e"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.79+9f235a105.tar.xz",
-        "version": "0.15.0-dev.79+9f235a105",
-        "sha256": "8972343a3be743f5fa715335ae88b345e790a6d5f0a7088cf9b28576cb8da25c"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "version": "0.15.0-dev.91+98640cbeb",
+        "sha256": "d54233f8c65fd0d578d40434c7bb86ae29f346d6593362a9fb1903d67a4aeee9"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.79+9f235a105.tar.xz",
-        "version": "0.15.0-dev.79+9f235a105",
-        "sha256": "3b8d330a6764236117316269fb86e4e072396aa175b4671aa689132b4504b8e9"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "version": "0.15.0-dev.91+98640cbeb",
+        "sha256": "ba90d0632fa4d29d2628e41475c3d11f8894e0afab859c3dac49b834310092b6"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.79+9f235a105.zip",
-        "sha256": "3039e41b80044e00fc502639072fa74439a9f4b406a68988ef9ec7fdd73866d5",
-        "version": "0.15.0-dev.79+9f235a105"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.91+98640cbeb.zip",
+        "sha256": "8fd5e0a2678377e36b12e8e01e0e64157edea1ad4dc02b66078da3d9ed47d14b",
+        "version": "0.15.0-dev.91+98640cbeb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.79+9f235a105.zip",
-        "sha256": "215526b7a4de93060d63c5d490330f852453b5bf1df6245e214a7681eda87d13",
-        "version": "0.15.0-dev.79+9f235a105"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.91+98640cbeb.zip",
+        "sha256": "64957a8108869f6b9f49f50cef83bb594b09a875111465ffafd395a8a1fea33f",
+        "version": "0.15.0-dev.91+98640cbeb"
       }
     },
     "2021-02-20": {
@@ -23767,6 +23767,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.79+9f235a105.zip",
         "sha256": "215526b7a4de93060d63c5d490330f852453b5bf1df6245e214a7681eda87d13",
         "version": "0.15.0-dev.79+9f235a105"
+      }
+    },
+    "2025-03-24": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "sha256": "d54233f8c65fd0d578d40434c7bb86ae29f346d6593362a9fb1903d67a4aeee9",
+        "version": "0.15.0-dev.91+98640cbeb"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "sha256": "ba90d0632fa4d29d2628e41475c3d11f8894e0afab859c3dac49b834310092b6",
+        "version": "0.15.0-dev.91+98640cbeb"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "sha256": "686ddca588e0ffa768278413db84c11167f6196771787691e4ba6fb5fd7a88b3",
+        "version": "0.15.0-dev.91+98640cbeb"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.91+98640cbeb.tar.xz",
+        "sha256": "84bd895cbf75bcda78108e621a02c1e9beda54f38f7f175ab70a4376b8ff199e",
+        "version": "0.15.0-dev.91+98640cbeb"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.91+98640cbeb.zip",
+        "sha256": "8fd5e0a2678377e36b12e8e01e0e64157edea1ad4dc02b66078da3d9ed47d14b",
+        "version": "0.15.0-dev.91+98640cbeb"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.91+98640cbeb.zip",
+        "sha256": "64957a8108869f6b9f49f50cef83bb594b09a875111465ffafd395a8a1fea33f",
+        "version": "0.15.0-dev.91+98640cbeb"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.77+aa8aa6625.tar.xz",
-        "version": "0.15.0-dev.77+aa8aa6625",
-        "sha256": "98c78ee83514bcf55b0bff3cb30516123d86c23ca2a5a49e0d5c0119dcbd88fb"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "version": "0.15.0-dev.78+9c9d3931d",
+        "sha256": "8f3d6072356406d30478566764285d509a3de163f1306946c173f012f0647316"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.77+aa8aa6625.tar.xz",
-        "version": "0.15.0-dev.77+aa8aa6625",
-        "sha256": "2669cf5980229c5bed244dc8b17f3d630ef28a83ce9171b4a678874afdfc9792"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "version": "0.15.0-dev.78+9c9d3931d",
+        "sha256": "524cfd040f2230df569200b723329acabd49e94085320b913d09e414939ed233"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.77+aa8aa6625.tar.xz",
-        "version": "0.15.0-dev.77+aa8aa6625",
-        "sha256": "95134bdb9cf3ba3797881557add39b0cb6dac430d0c8ac5615f9e1b5163ba673"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "version": "0.15.0-dev.78+9c9d3931d",
+        "sha256": "6590f2bd6f815129b3ef7ff13413ec9372f12ff5e6ea81b69e59332b3d521065"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.77+aa8aa6625.tar.xz",
-        "version": "0.15.0-dev.77+aa8aa6625",
-        "sha256": "823f98609eabee6386d02280962c0e9f1f55297d76f9ffa7b059e3f5bbb1fede"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "version": "0.15.0-dev.78+9c9d3931d",
+        "sha256": "6a6cf6b793af38cfeeab66fb74b4fb7cccb25565a9f541a61bbb4926c2b153fd"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.77+aa8aa6625.zip",
-        "sha256": "1cd3baf0ce5022a928c71594c4e10cae8b5c90f4bdc957258cc925aa0a0b4d5d",
-        "version": "0.15.0-dev.77+aa8aa6625"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.78+9c9d3931d.zip",
+        "sha256": "463703b500434cf5720170bb38afd6b5777c6703a6a97732ccfe8cfd812fe456",
+        "version": "0.15.0-dev.78+9c9d3931d"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.77+aa8aa6625.zip",
-        "sha256": "5b3c118831c3a01ecb6cb543ccfbb675ad27ffec30c9d96c68343f4b1207c064",
-        "version": "0.15.0-dev.77+aa8aa6625"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.78+9c9d3931d.zip",
+        "sha256": "adc3b7b22df6d5145cd943c5c68bd1b5f81141be70beab6ea6cb830b353de101",
+        "version": "0.15.0-dev.78+9c9d3931d"
       }
     },
     "2021-02-20": {
@@ -23703,6 +23703,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.77+aa8aa6625.zip",
         "sha256": "5b3c118831c3a01ecb6cb543ccfbb675ad27ffec30c9d96c68343f4b1207c064",
         "version": "0.15.0-dev.77+aa8aa6625"
+      }
+    },
+    "2025-03-22": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "sha256": "6590f2bd6f815129b3ef7ff13413ec9372f12ff5e6ea81b69e59332b3d521065",
+        "version": "0.15.0-dev.78+9c9d3931d"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "sha256": "6a6cf6b793af38cfeeab66fb74b4fb7cccb25565a9f541a61bbb4926c2b153fd",
+        "version": "0.15.0-dev.78+9c9d3931d"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "sha256": "8f3d6072356406d30478566764285d509a3de163f1306946c173f012f0647316",
+        "version": "0.15.0-dev.78+9c9d3931d"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.78+9c9d3931d.tar.xz",
+        "sha256": "524cfd040f2230df569200b723329acabd49e94085320b913d09e414939ed233",
+        "version": "0.15.0-dev.78+9c9d3931d"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.78+9c9d3931d.zip",
+        "sha256": "463703b500434cf5720170bb38afd6b5777c6703a6a97732ccfe8cfd812fe456",
+        "version": "0.15.0-dev.78+9c9d3931d"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.78+9c9d3931d.zip",
+        "sha256": "adc3b7b22df6d5145cd943c5c68bd1b5f81141be70beab6ea6cb830b353de101",
+        "version": "0.15.0-dev.78+9c9d3931d"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.56+d0911786c.tar.xz",
-        "version": "0.15.0-dev.56+d0911786c",
-        "sha256": "54ef448d32520ca10641f18c4e0a4393f762461d1e351ff075683c391951628d"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "version": "0.15.0-dev.58+1f92b394e",
+        "sha256": "661de357dec6b15037742f86ca73a09ed3b911567d9e7e874cb7a3f44d0287a3"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.56+d0911786c.tar.xz",
-        "version": "0.15.0-dev.56+d0911786c",
-        "sha256": "55234d068a5a60851c39052431037762fb3447af691751f826c6faf5ab7d0850"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "version": "0.15.0-dev.58+1f92b394e",
+        "sha256": "2958b4c59c83ec555111b11e0cfc1f395c5f7b12a5ce7080e983fd1c8fa5f3b8"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.56+d0911786c.tar.xz",
-        "version": "0.15.0-dev.56+d0911786c",
-        "sha256": "a737bf40b6b4627833c2346f4d1ab63c387e16e70c535cec421029efbf792826"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "version": "0.15.0-dev.58+1f92b394e",
+        "sha256": "b249bac08d501bb8cf6f9c7105b5a96c5386157200ffddaff873a86ee0a26fb0"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.56+d0911786c.tar.xz",
-        "version": "0.15.0-dev.56+d0911786c",
-        "sha256": "ef8f0429fa663c55807a60c3931fddc971276dd4570ca794a81c20c6cabfb56d"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "version": "0.15.0-dev.58+1f92b394e",
+        "sha256": "df257d9a0d9653f397fff1234af545a89842b722ecc97d5314c7f411cf801ab6"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.56+d0911786c.zip",
-        "sha256": "05c71d9a820a883589fc34e2e82d49a7ce1263b5957d58ae83ab9f3de02aae14",
-        "version": "0.15.0-dev.56+d0911786c"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.58+1f92b394e.zip",
+        "sha256": "7fb61b1ce8b124922de2fba94685702293ad805dd9eeddb127ee5f4fe528c396",
+        "version": "0.15.0-dev.58+1f92b394e"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.56+d0911786c.zip",
-        "sha256": "f620259d96ab0d60725ce86dedfe11b1c061acdff1d5f4e4cae5806d9d9477a2",
-        "version": "0.15.0-dev.56+d0911786c"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.58+1f92b394e.zip",
+        "sha256": "60c7d50433c6996dcf3f3141128f1bb7975e6abc830f964cdf4faeaf239e91b1",
+        "version": "0.15.0-dev.58+1f92b394e"
       }
     },
     "2021-02-20": {
@@ -23543,6 +23543,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.56+d0911786c.zip",
         "sha256": "f620259d96ab0d60725ce86dedfe11b1c061acdff1d5f4e4cae5806d9d9477a2",
         "version": "0.15.0-dev.56+d0911786c"
+      }
+    },
+    "2025-03-15": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "sha256": "b249bac08d501bb8cf6f9c7105b5a96c5386157200ffddaff873a86ee0a26fb0",
+        "version": "0.15.0-dev.58+1f92b394e"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "sha256": "df257d9a0d9653f397fff1234af545a89842b722ecc97d5314c7f411cf801ab6",
+        "version": "0.15.0-dev.58+1f92b394e"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "sha256": "661de357dec6b15037742f86ca73a09ed3b911567d9e7e874cb7a3f44d0287a3",
+        "version": "0.15.0-dev.58+1f92b394e"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.58+1f92b394e.tar.xz",
+        "sha256": "2958b4c59c83ec555111b11e0cfc1f395c5f7b12a5ce7080e983fd1c8fa5f3b8",
+        "version": "0.15.0-dev.58+1f92b394e"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.58+1f92b394e.zip",
+        "sha256": "7fb61b1ce8b124922de2fba94685702293ad805dd9eeddb127ee5f4fe528c396",
+        "version": "0.15.0-dev.58+1f92b394e"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.58+1f92b394e.zip",
+        "sha256": "60c7d50433c6996dcf3f3141128f1bb7975e6abc830f964cdf4faeaf239e91b1",
+        "version": "0.15.0-dev.58+1f92b394e"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3223+13ad984b1.tar.xz",
-        "version": "0.14.0-dev.3223+13ad984b1",
-        "sha256": "547cff1c77a4dfd8b5ba54c756ca4e5e328c42fbe1b7ce7edfc35fd9794e75c8"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "version": "0.14.0-dev.3224+5ab511307",
+        "sha256": "80667941010ee58b4102d19df35dc5c917d4bdf06ccf91a72b67d8b47fb90bb8"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3223+13ad984b1.tar.xz",
-        "version": "0.14.0-dev.3223+13ad984b1",
-        "sha256": "f1ad1b6bbcfd8437496db64329d8607eca3cf473d9a7570f2226c0f7bdd1a13a"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "version": "0.14.0-dev.3224+5ab511307",
+        "sha256": "8be2709d353e14bf2688c57512c7a6491d155d88e1562fec3a032caf5d428d7b"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3223+13ad984b1.tar.xz",
-        "version": "0.14.0-dev.3223+13ad984b1",
-        "sha256": "f312591c073f54df2737db547f97c16ca55bcda263008f0cbdfacfd1cd131b07"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "version": "0.14.0-dev.3224+5ab511307",
+        "sha256": "82f869c7a7b518b20d37dac7c8d2321232865699cb351427fa8d0fdf6eccb01b"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3223+13ad984b1.tar.xz",
-        "version": "0.14.0-dev.3223+13ad984b1",
-        "sha256": "eea72eec1f854394dc998edb8ef2b509afe924cb05d2745ae027993cc9116824"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "version": "0.14.0-dev.3224+5ab511307",
+        "sha256": "a7c684b5d68fbf56345e83bfeb4f588ff61992abcb8db78b8a05038204c036ab"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3223+13ad984b1.zip",
-        "sha256": "5589a5e3afe8ae41ea21aa461ba91484a6f785655a32e7a448217e5d1a603366",
-        "version": "0.14.0-dev.3223+13ad984b1"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3224+5ab511307.zip",
+        "sha256": "82bcf4c001cfc8b02c43da89902f0e0080852ac02b4b045622b261d368d6f368",
+        "version": "0.14.0-dev.3224+5ab511307"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3223+13ad984b1.zip",
-        "sha256": "9e727ec7d44d3705c1be5a3166ead932d0325a5505d524b57c188fe5638305d3",
-        "version": "0.14.0-dev.3223+13ad984b1"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3224+5ab511307.zip",
+        "sha256": "a63281acc32e8829c3a1dd921e6f71fcf057011b0487ff602bab95eae21f06f5",
+        "version": "0.14.0-dev.3224+5ab511307"
       }
     },
     "2021-02-20": {
@@ -22807,6 +22807,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3223+13ad984b1.zip",
         "sha256": "9e727ec7d44d3705c1be5a3166ead932d0325a5505d524b57c188fe5638305d3",
         "version": "0.14.0-dev.3223+13ad984b1"
+      }
+    },
+    "2025-02-16": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "sha256": "82f869c7a7b518b20d37dac7c8d2321232865699cb351427fa8d0fdf6eccb01b",
+        "version": "0.14.0-dev.3224+5ab511307"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "sha256": "a7c684b5d68fbf56345e83bfeb4f588ff61992abcb8db78b8a05038204c036ab",
+        "version": "0.14.0-dev.3224+5ab511307"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "sha256": "80667941010ee58b4102d19df35dc5c917d4bdf06ccf91a72b67d8b47fb90bb8",
+        "version": "0.14.0-dev.3224+5ab511307"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3224+5ab511307.tar.xz",
+        "sha256": "8be2709d353e14bf2688c57512c7a6491d155d88e1562fec3a032caf5d428d7b",
+        "version": "0.14.0-dev.3224+5ab511307"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3224+5ab511307.zip",
+        "sha256": "82bcf4c001cfc8b02c43da89902f0e0080852ac02b4b045622b261d368d6f368",
+        "version": "0.14.0-dev.3224+5ab511307"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3224+5ab511307.zip",
+        "sha256": "a63281acc32e8829c3a1dd921e6f71fcf057011b0487ff602bab95eae21f06f5",
+        "version": "0.14.0-dev.3224+5ab511307"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
-        "version": "0.15.0-dev.132+263ba3461",
-        "sha256": "ba59af2c5ad033ddb03930c1868c5ff4d47e4d8de50d3ea7235d2a93a42cf959"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "version": "0.15.0-dev.149+2b57f6b71",
+        "sha256": "f7a7e9e450a46efff2b194bd75a8eda3d587ba15b9b3bd58b94a519892ea3e35"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
-        "version": "0.15.0-dev.132+263ba3461",
-        "sha256": "a941072db4b95ae223aec7ed25eb16b0720663c459266eea3c01b2aae9a69281"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "version": "0.15.0-dev.149+2b57f6b71",
+        "sha256": "78a191a7783a0830d212ae092d46681e9adc75d2cfe0a9c835022da2991041d8"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
-        "version": "0.15.0-dev.132+263ba3461",
-        "sha256": "add829b6a95c1196ee141ab3d8c96686f87ceb7358ae5cbd87136bfbde4951cc"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "version": "0.15.0-dev.149+2b57f6b71",
+        "sha256": "e69a4e7da394ae8b47027b627d84892d093268ffc789a2428c6483c71070a8e3"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
-        "version": "0.15.0-dev.132+263ba3461",
-        "sha256": "ab1fac877416a1e1203a6efeef764a3e7a35c07a928700ff4fa88ce6c56f41cf"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "version": "0.15.0-dev.149+2b57f6b71",
+        "sha256": "709791e07ded6f8ce06852e0ba944e765ad3656706c2231e8695c0c54c924ceb"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.132+263ba3461.zip",
-        "sha256": "37953bbf179efaa30f4f62e6cbba9f686268cd05a714744f32975bfc9fe9e29e",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.149+2b57f6b71.zip",
+        "sha256": "81e101d0c33d649c6fd94d92a67bceff6f58e4923ba4d6bf89f59b622c4a5bcd",
+        "version": "0.15.0-dev.149+2b57f6b71"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.132+263ba3461.zip",
-        "sha256": "a9d7679c9a02b3a81cc0fa461932b9d687a79f53f2fdb5b3954a3b507ef98f5f",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.149+2b57f6b71.zip",
+        "sha256": "c2b03e0f46837961d978000d3b1c70c11f68a5650c43034ada5eb374f46fd107",
+        "version": "0.15.0-dev.149+2b57f6b71"
       }
     },
     "2021-02-20": {
@@ -23899,34 +23899,34 @@
     },
     "2025-03-28": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
-        "sha256": "add829b6a95c1196ee141ab3d8c96686f87ceb7358ae5cbd87136bfbde4951cc",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "sha256": "e69a4e7da394ae8b47027b627d84892d093268ffc789a2428c6483c71070a8e3",
+        "version": "0.15.0-dev.149+2b57f6b71"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
-        "sha256": "ab1fac877416a1e1203a6efeef764a3e7a35c07a928700ff4fa88ce6c56f41cf",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "sha256": "709791e07ded6f8ce06852e0ba944e765ad3656706c2231e8695c0c54c924ceb",
+        "version": "0.15.0-dev.149+2b57f6b71"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
-        "sha256": "ba59af2c5ad033ddb03930c1868c5ff4d47e4d8de50d3ea7235d2a93a42cf959",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "sha256": "f7a7e9e450a46efff2b194bd75a8eda3d587ba15b9b3bd58b94a519892ea3e35",
+        "version": "0.15.0-dev.149+2b57f6b71"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
-        "sha256": "a941072db4b95ae223aec7ed25eb16b0720663c459266eea3c01b2aae9a69281",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.149+2b57f6b71.tar.xz",
+        "sha256": "78a191a7783a0830d212ae092d46681e9adc75d2cfe0a9c835022da2991041d8",
+        "version": "0.15.0-dev.149+2b57f6b71"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.132+263ba3461.zip",
-        "sha256": "37953bbf179efaa30f4f62e6cbba9f686268cd05a714744f32975bfc9fe9e29e",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.149+2b57f6b71.zip",
+        "sha256": "81e101d0c33d649c6fd94d92a67bceff6f58e4923ba4d6bf89f59b622c4a5bcd",
+        "version": "0.15.0-dev.149+2b57f6b71"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.132+263ba3461.zip",
-        "sha256": "a9d7679c9a02b3a81cc0fa461932b9d687a79f53f2fdb5b3954a3b507ef98f5f",
-        "version": "0.15.0-dev.132+263ba3461"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.149+2b57f6b71.zip",
+        "sha256": "c2b03e0f46837961d978000d3b1c70c11f68a5650c43034ada5eb374f46fd107",
+        "version": "0.15.0-dev.149+2b57f6b71"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.149+2b57f6b71.tar.xz",
-        "version": "0.15.0-dev.149+2b57f6b71",
-        "sha256": "f7a7e9e450a46efff2b194bd75a8eda3d587ba15b9b3bd58b94a519892ea3e35"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "version": "0.15.0-dev.151+6e8493daa",
+        "sha256": "b769e825af9c71e22f2eef41323067a348931f05c25b2dadf7351ada38f80ece"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.149+2b57f6b71.tar.xz",
-        "version": "0.15.0-dev.149+2b57f6b71",
-        "sha256": "78a191a7783a0830d212ae092d46681e9adc75d2cfe0a9c835022da2991041d8"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "version": "0.15.0-dev.151+6e8493daa",
+        "sha256": "66c5c4cc2d74f6c6ec6b9ce5d0c60aad3d4fff97c86179c6952164c989827171"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.149+2b57f6b71.tar.xz",
-        "version": "0.15.0-dev.149+2b57f6b71",
-        "sha256": "e69a4e7da394ae8b47027b627d84892d093268ffc789a2428c6483c71070a8e3"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "version": "0.15.0-dev.151+6e8493daa",
+        "sha256": "6c48cebbdaa5562c9275e6e4ed44795b1297eadb5534527a820da6c8fae8619d"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.149+2b57f6b71.tar.xz",
-        "version": "0.15.0-dev.149+2b57f6b71",
-        "sha256": "709791e07ded6f8ce06852e0ba944e765ad3656706c2231e8695c0c54c924ceb"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "version": "0.15.0-dev.151+6e8493daa",
+        "sha256": "0e19ee189b7906cdb09a98940b3519b2a12cc5d6facebe720cae9fb7cd89e821"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.149+2b57f6b71.zip",
-        "sha256": "81e101d0c33d649c6fd94d92a67bceff6f58e4923ba4d6bf89f59b622c4a5bcd",
-        "version": "0.15.0-dev.149+2b57f6b71"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.151+6e8493daa.zip",
+        "sha256": "2c2fbea26ef9d2ab1d210c3da456d91b27f1846a9d14761c38af9ce23a04ea27",
+        "version": "0.15.0-dev.151+6e8493daa"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.149+2b57f6b71.zip",
-        "sha256": "c2b03e0f46837961d978000d3b1c70c11f68a5650c43034ada5eb374f46fd107",
-        "version": "0.15.0-dev.149+2b57f6b71"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.151+6e8493daa.zip",
+        "sha256": "112b600aad9c1403354a896f601785a0914ffa1f0aa07a9493120b92fb2da604",
+        "version": "0.15.0-dev.151+6e8493daa"
       }
     },
     "2021-02-20": {
@@ -23927,6 +23927,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.149+2b57f6b71.zip",
         "sha256": "c2b03e0f46837961d978000d3b1c70c11f68a5650c43034ada5eb374f46fd107",
         "version": "0.15.0-dev.149+2b57f6b71"
+      }
+    },
+    "2025-03-29": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "sha256": "6c48cebbdaa5562c9275e6e4ed44795b1297eadb5534527a820da6c8fae8619d",
+        "version": "0.15.0-dev.151+6e8493daa"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "sha256": "0e19ee189b7906cdb09a98940b3519b2a12cc5d6facebe720cae9fb7cd89e821",
+        "version": "0.15.0-dev.151+6e8493daa"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "sha256": "b769e825af9c71e22f2eef41323067a348931f05c25b2dadf7351ada38f80ece",
+        "version": "0.15.0-dev.151+6e8493daa"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.151+6e8493daa.tar.xz",
+        "sha256": "66c5c4cc2d74f6c6ec6b9ce5d0c60aad3d4fff97c86179c6952164c989827171",
+        "version": "0.15.0-dev.151+6e8493daa"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.151+6e8493daa.zip",
+        "sha256": "2c2fbea26ef9d2ab1d210c3da456d91b27f1846a9d14761c38af9ce23a04ea27",
+        "version": "0.15.0-dev.151+6e8493daa"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.151+6e8493daa.zip",
+        "sha256": "112b600aad9c1403354a896f601785a0914ffa1f0aa07a9493120b92fb2da604",
+        "version": "0.15.0-dev.151+6e8493daa"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.63+aa3db7cc1.tar.xz",
-        "version": "0.15.0-dev.63+aa3db7cc1",
-        "sha256": "1a89e6f49868c614d19af27174ac0b6355589599ed9c6754510ea1bcfb0ae4db"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "version": "0.15.0-dev.64+2a4e06bcb",
+        "sha256": "6dcf293c5bed4b20823a59c472634f862338772d3c57c60ba9150bb62ce2d784"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.63+aa3db7cc1.tar.xz",
-        "version": "0.15.0-dev.63+aa3db7cc1",
-        "sha256": "916f732c7df86e6a9479bc03e751121e547a006362bde526f6cfb58bae26ea2f"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "version": "0.15.0-dev.64+2a4e06bcb",
+        "sha256": "5202440dbe8d63b0c3af04e2ecc7924554e806bf597c717d0a7f242d6c7f8686"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.63+aa3db7cc1.tar.xz",
-        "version": "0.15.0-dev.63+aa3db7cc1",
-        "sha256": "f27298c809230db40efe2948b3eebd23bc01d2183845105dc9ac7eee6dd39d54"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "version": "0.15.0-dev.64+2a4e06bcb",
+        "sha256": "e0070febba66548fe752e9273df18cebca9e295804d7976f9e27a08a91b9c24e"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.63+aa3db7cc1.tar.xz",
-        "version": "0.15.0-dev.63+aa3db7cc1",
-        "sha256": "4fc59c67aca0cb60bca43ae667d4124fe6ae3df9c4a33ba4593116e3f89bc2ca"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "version": "0.15.0-dev.64+2a4e06bcb",
+        "sha256": "a982caf087042ea897b4cfe755928402d6f70f46145ebb93d07404b498847ca1"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.63+aa3db7cc1.zip",
-        "sha256": "c51d0d5f5fbc458f41d0f8059007d7c56d8f7111ec991b6cb643d72a7fae9385",
-        "version": "0.15.0-dev.63+aa3db7cc1"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.64+2a4e06bcb.zip",
+        "sha256": "8c9db33e5904dc5cd14b56adc689148cf1bdae751317431f2c6b4823016599fb",
+        "version": "0.15.0-dev.64+2a4e06bcb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.63+aa3db7cc1.zip",
-        "sha256": "e1516739215ede9cacbadaf341e59c0afff846573a24e434994b5e65de792c9d",
-        "version": "0.15.0-dev.63+aa3db7cc1"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.64+2a4e06bcb.zip",
+        "sha256": "8a82a460ed1c4cbce4a996cc60320f627a7fd37c528a81cd7cd2a171761d28fe",
+        "version": "0.15.0-dev.64+2a4e06bcb"
       }
     },
     "2021-02-20": {
@@ -23607,6 +23607,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.63+aa3db7cc1.zip",
         "sha256": "e1516739215ede9cacbadaf341e59c0afff846573a24e434994b5e65de792c9d",
         "version": "0.15.0-dev.63+aa3db7cc1"
+      }
+    },
+    "2025-03-17": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "sha256": "e0070febba66548fe752e9273df18cebca9e295804d7976f9e27a08a91b9c24e",
+        "version": "0.15.0-dev.64+2a4e06bcb"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "sha256": "a982caf087042ea897b4cfe755928402d6f70f46145ebb93d07404b498847ca1",
+        "version": "0.15.0-dev.64+2a4e06bcb"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "sha256": "6dcf293c5bed4b20823a59c472634f862338772d3c57c60ba9150bb62ce2d784",
+        "version": "0.15.0-dev.64+2a4e06bcb"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.64+2a4e06bcb.tar.xz",
+        "sha256": "5202440dbe8d63b0c3af04e2ecc7924554e806bf597c717d0a7f242d6c7f8686",
+        "version": "0.15.0-dev.64+2a4e06bcb"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.64+2a4e06bcb.zip",
+        "sha256": "8c9db33e5904dc5cd14b56adc689148cf1bdae751317431f2c6b4823016599fb",
+        "version": "0.15.0-dev.64+2a4e06bcb"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.64+2a4e06bcb.zip",
+        "sha256": "8a82a460ed1c4cbce4a996cc60320f627a7fd37c528a81cd7cd2a171761d28fe",
+        "version": "0.15.0-dev.64+2a4e06bcb"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3470+711b0fef5.tar.xz",
-        "version": "0.14.0-dev.3470+711b0fef5",
-        "sha256": "2779f8509e82eaada8c1616ecedd315ff32ecb6ce0e1816dbba0caabeb456d20"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0.tar.xz",
+        "version": "0.14.0",
+        "sha256": "d731dc81e1dff2d5f9b1d1979d554648df6d05f7723d1cc9e37430c7ca88d573"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3470+711b0fef5.tar.xz",
-        "version": "0.14.0-dev.3470+711b0fef5",
-        "sha256": "8eab22defba781eb60fd3feae5ba07cf00683657377df52a2987ba51f270025e"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0.tar.xz",
+        "version": "0.14.0",
+        "sha256": "d387b2dc29e4a078dc1d7969e0e8d58e96da1a9ba4cbb15c56297b414138bed0"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3470+711b0fef5.tar.xz",
-        "version": "0.14.0-dev.3470+711b0fef5",
-        "sha256": "959fcba0ef491701d469a9a6c1290007dc97504b98b5b9d3ad9a4f3c3dce2c97"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0.tar.xz",
+        "version": "0.14.0",
+        "sha256": "d8bca68733720c3352b5204783880fb7bb6df573d8e5846c974d4d6e98a1fce7"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3470+711b0fef5.tar.xz",
-        "version": "0.14.0-dev.3470+711b0fef5",
-        "sha256": "cdf5c17192ed78034237a22a1eda5f35a0438ddaaf9c426b0a92dd0f7862bd27"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0.tar.xz",
+        "version": "0.14.0",
+        "sha256": "860028deb178f8dc809135d51a52f30e5d3e645650a86fbbe3a8a12d73fe5486"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3470+711b0fef5.zip",
-        "sha256": "a9ba488527dcbd49a6c5d71e385b7cb82e65165c656e429a0a5c638c92d3399e",
-        "version": "0.14.0-dev.3470+711b0fef5"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0.zip",
+        "sha256": "ac331b5a18dc3d3b301ec658a9532f24de1fd350197e0f34caa559437eb8d022",
+        "version": "0.14.0"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3470+711b0fef5.zip",
-        "sha256": "4894ca99d5486397714a79380736938176489444bee8b81870f131be5b34f4f6",
-        "version": "0.14.0-dev.3470+711b0fef5"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0.zip",
+        "sha256": "7921e2696d5bd3741b2a1ef02b7126e59d90e32a267fece13669fb05b5e47f8c",
+        "version": "0.14.0"
       }
     },
     "2021-02-20": {
@@ -23383,6 +23383,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3470+711b0fef5.zip",
         "sha256": "4894ca99d5486397714a79380736938176489444bee8b81870f131be5b34f4f6",
         "version": "0.14.0-dev.3470+711b0fef5"
+      }
+    },
+    "2025-03-06": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0.tar.xz",
+        "sha256": "d8bca68733720c3352b5204783880fb7bb6df573d8e5846c974d4d6e98a1fce7",
+        "version": "0.14.0"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0.tar.xz",
+        "sha256": "860028deb178f8dc809135d51a52f30e5d3e645650a86fbbe3a8a12d73fe5486",
+        "version": "0.14.0"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0.tar.xz",
+        "sha256": "d731dc81e1dff2d5f9b1d1979d554648df6d05f7723d1cc9e37430c7ca88d573",
+        "version": "0.14.0"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0.tar.xz",
+        "sha256": "d387b2dc29e4a078dc1d7969e0e8d58e96da1a9ba4cbb15c56297b414138bed0",
+        "version": "0.14.0"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0.zip",
+        "sha256": "ac331b5a18dc3d3b301ec658a9532f24de1fd350197e0f34caa559437eb8d022",
+        "version": "0.14.0"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0.zip",
+        "sha256": "7921e2696d5bd3741b2a1ef02b7126e59d90e32a267fece13669fb05b5e47f8c",
+        "version": "0.14.0"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.91+98640cbeb.tar.xz",
-        "version": "0.15.0-dev.91+98640cbeb",
-        "sha256": "686ddca588e0ffa768278413db84c11167f6196771787691e4ba6fb5fd7a88b3"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "version": "0.15.0-dev.97+677b2d62e",
+        "sha256": "fcbfd041fec2afeb9b8074661406543c2108a2872b1ddce8f8403cc7d5297112"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.91+98640cbeb.tar.xz",
-        "version": "0.15.0-dev.91+98640cbeb",
-        "sha256": "84bd895cbf75bcda78108e621a02c1e9beda54f38f7f175ab70a4376b8ff199e"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "version": "0.15.0-dev.97+677b2d62e",
+        "sha256": "2d9f738b5c91814190d8a54404163f2430ee175c5c60b99e2a60e28d455cfcf0"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.91+98640cbeb.tar.xz",
-        "version": "0.15.0-dev.91+98640cbeb",
-        "sha256": "d54233f8c65fd0d578d40434c7bb86ae29f346d6593362a9fb1903d67a4aeee9"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "version": "0.15.0-dev.97+677b2d62e",
+        "sha256": "f62bd7c43ea88fd27d2a0b4804a2decd48902cf6fab84678a79baad8b756303f"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.91+98640cbeb.tar.xz",
-        "version": "0.15.0-dev.91+98640cbeb",
-        "sha256": "ba90d0632fa4d29d2628e41475c3d11f8894e0afab859c3dac49b834310092b6"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "version": "0.15.0-dev.97+677b2d62e",
+        "sha256": "7d6ff150384bd0f2ac1ade4ae3a82776cf75376fbc406ac9f42ec75dffeda6ae"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.91+98640cbeb.zip",
-        "sha256": "8fd5e0a2678377e36b12e8e01e0e64157edea1ad4dc02b66078da3d9ed47d14b",
-        "version": "0.15.0-dev.91+98640cbeb"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.97+677b2d62e.zip",
+        "sha256": "6d2dad59fedfcc53d72ef9e1c1f588599116a0bd11b151ac66aebbd567a9f772",
+        "version": "0.15.0-dev.97+677b2d62e"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.91+98640cbeb.zip",
-        "sha256": "64957a8108869f6b9f49f50cef83bb594b09a875111465ffafd395a8a1fea33f",
-        "version": "0.15.0-dev.91+98640cbeb"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.97+677b2d62e.zip",
+        "sha256": "805bcb21271951d5ac6208311f094f9aaaf70aeea80a551b5364687f84a8530b",
+        "version": "0.15.0-dev.97+677b2d62e"
       }
     },
     "2021-02-20": {
@@ -23799,6 +23799,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.91+98640cbeb.zip",
         "sha256": "64957a8108869f6b9f49f50cef83bb594b09a875111465ffafd395a8a1fea33f",
         "version": "0.15.0-dev.91+98640cbeb"
+      }
+    },
+    "2025-03-25": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "sha256": "f62bd7c43ea88fd27d2a0b4804a2decd48902cf6fab84678a79baad8b756303f",
+        "version": "0.15.0-dev.97+677b2d62e"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "sha256": "7d6ff150384bd0f2ac1ade4ae3a82776cf75376fbc406ac9f42ec75dffeda6ae",
+        "version": "0.15.0-dev.97+677b2d62e"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "sha256": "fcbfd041fec2afeb9b8074661406543c2108a2872b1ddce8f8403cc7d5297112",
+        "version": "0.15.0-dev.97+677b2d62e"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
+        "sha256": "2d9f738b5c91814190d8a54404163f2430ee175c5c60b99e2a60e28d455cfcf0",
+        "version": "0.15.0-dev.97+677b2d62e"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.97+677b2d62e.zip",
+        "sha256": "6d2dad59fedfcc53d72ef9e1c1f588599116a0bd11b151ac66aebbd567a9f772",
+        "version": "0.15.0-dev.97+677b2d62e"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.97+677b2d62e.zip",
+        "sha256": "805bcb21271951d5ac6208311f094f9aaaf70aeea80a551b5364687f84a8530b",
+        "version": "0.15.0-dev.97+677b2d62e"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.58+1f92b394e.tar.xz",
-        "version": "0.15.0-dev.58+1f92b394e",
-        "sha256": "661de357dec6b15037742f86ca73a09ed3b911567d9e7e874cb7a3f44d0287a3"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "version": "0.15.0-dev.62+ea57fb55e",
+        "sha256": "bb8994abbfec3d2afc042da2edba1eea0adb7e30bef07ff2c99fbeab5f0c267e"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.58+1f92b394e.tar.xz",
-        "version": "0.15.0-dev.58+1f92b394e",
-        "sha256": "2958b4c59c83ec555111b11e0cfc1f395c5f7b12a5ce7080e983fd1c8fa5f3b8"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "version": "0.15.0-dev.62+ea57fb55e",
+        "sha256": "da7d449e34776cfda3527afa351d20158251a5bf24e182cff128cee9bbc35f17"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.58+1f92b394e.tar.xz",
-        "version": "0.15.0-dev.58+1f92b394e",
-        "sha256": "b249bac08d501bb8cf6f9c7105b5a96c5386157200ffddaff873a86ee0a26fb0"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "version": "0.15.0-dev.62+ea57fb55e",
+        "sha256": "361185091f2430d865d8c363b847c541b52ff544569cedbd3c0bc57cdeedaeec"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.58+1f92b394e.tar.xz",
-        "version": "0.15.0-dev.58+1f92b394e",
-        "sha256": "df257d9a0d9653f397fff1234af545a89842b722ecc97d5314c7f411cf801ab6"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "version": "0.15.0-dev.62+ea57fb55e",
+        "sha256": "0378e33ddd36363a81138c59e02c4a46a22e6c8c3292cc23ffea485af376aa92"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.58+1f92b394e.zip",
-        "sha256": "7fb61b1ce8b124922de2fba94685702293ad805dd9eeddb127ee5f4fe528c396",
-        "version": "0.15.0-dev.58+1f92b394e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.62+ea57fb55e.zip",
+        "sha256": "c5de618597bc5c8e2419e6fcc97767c444cb46f9d7be9a3bf79d9829eb3970b3",
+        "version": "0.15.0-dev.62+ea57fb55e"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.58+1f92b394e.zip",
-        "sha256": "60c7d50433c6996dcf3f3141128f1bb7975e6abc830f964cdf4faeaf239e91b1",
-        "version": "0.15.0-dev.58+1f92b394e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.62+ea57fb55e.zip",
+        "sha256": "03e81a2b8cdeb8eeb68fbc3ef3b52dd87fa75ca36dd01f6bb3b0620b7472864f",
+        "version": "0.15.0-dev.62+ea57fb55e"
       }
     },
     "2021-02-20": {
@@ -23575,6 +23575,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.58+1f92b394e.zip",
         "sha256": "60c7d50433c6996dcf3f3141128f1bb7975e6abc830f964cdf4faeaf239e91b1",
         "version": "0.15.0-dev.58+1f92b394e"
+      }
+    },
+    "2025-03-16": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "sha256": "361185091f2430d865d8c363b847c541b52ff544569cedbd3c0bc57cdeedaeec",
+        "version": "0.15.0-dev.62+ea57fb55e"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "sha256": "0378e33ddd36363a81138c59e02c4a46a22e6c8c3292cc23ffea485af376aa92",
+        "version": "0.15.0-dev.62+ea57fb55e"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "sha256": "bb8994abbfec3d2afc042da2edba1eea0adb7e30bef07ff2c99fbeab5f0c267e",
+        "version": "0.15.0-dev.62+ea57fb55e"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
+        "sha256": "da7d449e34776cfda3527afa351d20158251a5bf24e182cff128cee9bbc35f17",
+        "version": "0.15.0-dev.62+ea57fb55e"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.62+ea57fb55e.zip",
+        "sha256": "c5de618597bc5c8e2419e6fcc97767c444cb46f9d7be9a3bf79d9829eb3970b3",
+        "version": "0.15.0-dev.62+ea57fb55e"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.62+ea57fb55e.zip",
+        "sha256": "03e81a2b8cdeb8eeb68fbc3ef3b52dd87fa75ca36dd01f6bb3b0620b7472864f",
+        "version": "0.15.0-dev.62+ea57fb55e"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3446+50b40c962.tar.xz",
-        "version": "0.14.0-dev.3446+50b40c962",
-        "sha256": "be56e88cafddaacbe47b5a2dad8b858b6d946523c14e600facb03f185658bb27"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "version": "0.14.0-dev.3451+d8d2aa9af",
+        "sha256": "a9b2aeaea89a93bb4d5f390007259b776d53b4537e4a060a07f4e6b530f1f38c"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3446+50b40c962.tar.xz",
-        "version": "0.14.0-dev.3446+50b40c962",
-        "sha256": "1499978969569c405590a02415150e98c71356a6b9deceb1960cc29b3a385462"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "version": "0.14.0-dev.3451+d8d2aa9af",
+        "sha256": "941f2f0892af4ed794253527320fc80f41dbb6168a119648ca0401eeda9205b6"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3446+50b40c962.tar.xz",
-        "version": "0.14.0-dev.3446+50b40c962",
-        "sha256": "9364ee45e94ed3d01ee15e7cb71d516c520860a6a7c44e6f809c86fd71359525"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "version": "0.14.0-dev.3451+d8d2aa9af",
+        "sha256": "bac6171f60244e7f95f6565210f295786a5da2469b3e1b2a6d2e133745c7d6ab"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3446+50b40c962.tar.xz",
-        "version": "0.14.0-dev.3446+50b40c962",
-        "sha256": "1b6a8e9333d4a4017fb4a88013e4ec0fc076b658ada650f189b2bf06f723a5be"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "version": "0.14.0-dev.3451+d8d2aa9af",
+        "sha256": "fdc3c7139a3fb5f7e6d3c2b9c8174c85c6c5ebe1d04f9b8467f1cebcd31421aa"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3446+50b40c962.zip",
-        "sha256": "5c0e086eb8353be276279c45f06fbe36fcf7af6b8415148a659999776e681815",
-        "version": "0.14.0-dev.3446+50b40c962"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3451+d8d2aa9af.zip",
+        "sha256": "a451bb0ec577db5ee7f6b24d27a211b0a9064d5998a0066c80760eab079229fa",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3446+50b40c962.zip",
-        "sha256": "7daa702382c7b02c3dc528e8dd1fd20cdb5b84d79bed091fd23f9e2afd09706a",
-        "version": "0.14.0-dev.3446+50b40c962"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3451+d8d2aa9af.zip",
+        "sha256": "b5614dc4a5d68a64254fd826165837dfa8dbf30bf91168e74cfcdd53301d5a4f",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
       }
     },
     "2021-02-20": {
@@ -23287,6 +23287,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3446+50b40c962.zip",
         "sha256": "7daa702382c7b02c3dc528e8dd1fd20cdb5b84d79bed091fd23f9e2afd09706a",
         "version": "0.14.0-dev.3446+50b40c962"
+      }
+    },
+    "2025-03-03": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "sha256": "bac6171f60244e7f95f6565210f295786a5da2469b3e1b2a6d2e133745c7d6ab",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "sha256": "fdc3c7139a3fb5f7e6d3c2b9c8174c85c6c5ebe1d04f9b8467f1cebcd31421aa",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "sha256": "a9b2aeaea89a93bb4d5f390007259b776d53b4537e4a060a07f4e6b530f1f38c",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
+        "sha256": "941f2f0892af4ed794253527320fc80f41dbb6168a119648ca0401eeda9205b6",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3451+d8d2aa9af.zip",
+        "sha256": "a451bb0ec577db5ee7f6b24d27a211b0a9064d5998a0066c80760eab079229fa",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3451+d8d2aa9af.zip",
+        "sha256": "b5614dc4a5d68a64254fd826165837dfa8dbf30bf91168e74cfcdd53301d5a4f",
+        "version": "0.14.0-dev.3451+d8d2aa9af"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "version": "0.15.0-dev.169+fa86e09fb",
-        "sha256": "b9232b7b648acfcab61371b24396a71de4c4c66b7f27f8c6ac6c572fa221a30c"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "version": "0.15.0-dev.171+1b62a2226",
+        "sha256": "dc102dac855e9dbe9db9f81c1be2da5e1d3b6b180ae140c74e89d5d18a374f78"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "version": "0.15.0-dev.169+fa86e09fb",
-        "sha256": "ae0d67e172fc51c25b722486825a50203d1be5e7697638d6337b49b45437c4b5"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "version": "0.15.0-dev.171+1b62a2226",
+        "sha256": "3091a253f5ed8133051074aefd29d72d22a0ae8efb45387565b60512bc7efc44"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "version": "0.15.0-dev.169+fa86e09fb",
-        "sha256": "da6f02b4c09b560601630a19c84293501d7ed43e7ceb0d1038822454be161a39"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "version": "0.15.0-dev.171+1b62a2226",
+        "sha256": "c6fa8c9f54707542108bfe17a8d56f66357130d5bc419d3f916ae264744b02b1"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "version": "0.15.0-dev.169+fa86e09fb",
-        "sha256": "179c5e665a8b473e6773c0e7cb69cb0aa959f0845f5db8a3d2ec2097f92cd548"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "version": "0.15.0-dev.171+1b62a2226",
+        "sha256": "df150689281b1334c093308eaae740c128fad883095b4ab26878bf0ca491d34f"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.169+fa86e09fb.zip",
-        "sha256": "9770abc49e2ffc6698a14343733315016db938abb008f91898c4789a22bcf698",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.171+1b62a2226.zip",
+        "sha256": "dcdc7679ba5084822ec979d46f4d8d70bdf6987fb5b0842bef458905076fdbff",
+        "version": "0.15.0-dev.171+1b62a2226"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.169+fa86e09fb.zip",
-        "sha256": "b02411fcf2a681ec97bf385744e86ca23a8b0fc20879cc3883930423d4f408f7",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.171+1b62a2226.zip",
+        "sha256": "4e1225204e968d9bbb7ee8d674444c9d164131878dea1f6cf63224433ca92faf",
+        "version": "0.15.0-dev.171+1b62a2226"
       }
     },
     "2021-02-20": {
@@ -24027,34 +24027,34 @@
     },
     "2025-04-02": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "sha256": "da6f02b4c09b560601630a19c84293501d7ed43e7ceb0d1038822454be161a39",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "sha256": "c6fa8c9f54707542108bfe17a8d56f66357130d5bc419d3f916ae264744b02b1",
+        "version": "0.15.0-dev.171+1b62a2226"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "sha256": "179c5e665a8b473e6773c0e7cb69cb0aa959f0845f5db8a3d2ec2097f92cd548",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "sha256": "df150689281b1334c093308eaae740c128fad883095b4ab26878bf0ca491d34f",
+        "version": "0.15.0-dev.171+1b62a2226"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "sha256": "b9232b7b648acfcab61371b24396a71de4c4c66b7f27f8c6ac6c572fa221a30c",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "sha256": "dc102dac855e9dbe9db9f81c1be2da5e1d3b6b180ae140c74e89d5d18a374f78",
+        "version": "0.15.0-dev.171+1b62a2226"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
-        "sha256": "ae0d67e172fc51c25b722486825a50203d1be5e7697638d6337b49b45437c4b5",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.171+1b62a2226.tar.xz",
+        "sha256": "3091a253f5ed8133051074aefd29d72d22a0ae8efb45387565b60512bc7efc44",
+        "version": "0.15.0-dev.171+1b62a2226"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.169+fa86e09fb.zip",
-        "sha256": "9770abc49e2ffc6698a14343733315016db938abb008f91898c4789a22bcf698",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.171+1b62a2226.zip",
+        "sha256": "dcdc7679ba5084822ec979d46f4d8d70bdf6987fb5b0842bef458905076fdbff",
+        "version": "0.15.0-dev.171+1b62a2226"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.169+fa86e09fb.zip",
-        "sha256": "b02411fcf2a681ec97bf385744e86ca23a8b0fc20879cc3883930423d4f408f7",
-        "version": "0.15.0-dev.169+fa86e09fb"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.171+1b62a2226.zip",
+        "sha256": "4e1225204e968d9bbb7ee8d674444c9d164131878dea1f6cf63224433ca92faf",
+        "version": "0.15.0-dev.171+1b62a2226"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -24152,6 +24152,36 @@
         "sha256": "da86aec0b5d249a701f259a5f5cb76e7497454656d07f7a3790810b42bac829e",
         "version": "0.15.0-dev.208+8acedfd5b"
       }
+    },
+    "x86_64-darwin": {
+      "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.208+8acedfd5b.tar.xz",
+      "sha256": "8f79a0bf8ca06cdb9a66f7b4ad252d7bd5e35e6a48b687ea321df847a4e4e422",
+      "version": "master"
+    },
+    "aarch64-darwin": {
+      "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.208+8acedfd5b.tar.xz",
+      "sha256": "d46f997363bc6437c0d389f7f05f922072adc50f45b9ce67a0015d54695499a4",
+      "version": "master"
+    },
+    "x86_64-linux": {
+      "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.208+8acedfd5b.tar.xz",
+      "sha256": "af7903e257e31693052aeca20b8fefcc3cf22ca2a39b6f2cacf7f19262896db6",
+      "version": "master"
+    },
+    "aarch64-linux": {
+      "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.208+8acedfd5b.tar.xz",
+      "sha256": "8ed628d03398ea0d20e8a96896de929cfb66f00c0b273c04b2fc4158c08a23ef",
+      "version": "master"
+    },
+    "x86_64-windows": {
+      "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.208+8acedfd5b.zip",
+      "sha256": "2f8dbbd52331ba12b80b9688d0fc616c02c47c169d3bef5044fad07ebb9811ae",
+      "version": "master"
+    },
+    "aarch64-windows": {
+      "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.208+8acedfd5b.zip",
+      "sha256": "da86aec0b5d249a701f259a5f5cb76e7497454656d07f7a3790810b42bac829e",
+      "version": "master"
     }
   },
   "0.7.1": {
@@ -24710,6 +24740,326 @@
       "url": "https://ziglang.org/download/0.14.0/zig-windows-aarch64-0.14.0.zip",
       "sha256": "03e984383ebb8f85293557cfa9f48ee8698e7c400239570c9ff1aef3bffaf046",
       "version": "0.14.0"
+    }
+  },
+  "mach-latest": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "19e0b3673fd16609f7ce504faadb1c988270c2ed7cb250a7a9cb74beb22a4c23",
+      "version": "mach-latest"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "034d395256d9f8b9f4e9fb07bc3428336b5138853dc2d518898fa0fa8fab434f",
+      "version": "mach-latest"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "7be6abdebfa970c6138d165b348d0464e84f16f531e71cb20c0e052fae1d8c8d",
+      "version": "mach-latest"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "cafbc9b83e624d8e7e55c41991c2c8d33b52d25661d94c27f236fb622ce168e4",
+      "version": "mach-latest"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.14.0-dev.2577+271452d22.zip",
+      "sha256": "23f0c4a4f789b6e1a82861bc14ea80652ba1d75784fcca55e74d50be24cf60e9",
+      "version": "mach-latest"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.14.0-dev.2577+271452d22.zip",
+      "sha256": "3563af9bf14a8e510c02c7858320db712348557b71a7d9844d8a960363207518",
+      "version": "mach-latest"
+    },
+    "latest": {
+      "x86_64-darwin": {
+        "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "19e0b3673fd16609f7ce504faadb1c988270c2ed7cb250a7a9cb74beb22a4c23",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "aarch64-darwin": {
+        "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "034d395256d9f8b9f4e9fb07bc3428336b5138853dc2d518898fa0fa8fab434f",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "x86_64-linux": {
+        "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "7be6abdebfa970c6138d165b348d0464e84f16f531e71cb20c0e052fae1d8c8d",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "aarch64-linux": {
+        "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "cafbc9b83e624d8e7e55c41991c2c8d33b52d25661d94c27f236fb622ce168e4",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "x86_64-windows": {
+        "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.14.0-dev.2577+271452d22.zip",
+        "sha256": "23f0c4a4f789b6e1a82861bc14ea80652ba1d75784fcca55e74d50be24cf60e9",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "aarch64-windows": {
+        "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.14.0-dev.2577+271452d22.zip",
+        "sha256": "3563af9bf14a8e510c02c7858320db712348557b71a7d9844d8a960363207518",
+        "version": "0.14.0-dev.2577+271452d22"
+      }
+    },
+    "2024-12-30": {
+      "x86_64-darwin": {
+        "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "19e0b3673fd16609f7ce504faadb1c988270c2ed7cb250a7a9cb74beb22a4c23",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "aarch64-darwin": {
+        "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "034d395256d9f8b9f4e9fb07bc3428336b5138853dc2d518898fa0fa8fab434f",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "x86_64-linux": {
+        "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "7be6abdebfa970c6138d165b348d0464e84f16f531e71cb20c0e052fae1d8c8d",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "aarch64-linux": {
+        "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+        "sha256": "cafbc9b83e624d8e7e55c41991c2c8d33b52d25661d94c27f236fb622ce168e4",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "x86_64-windows": {
+        "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.14.0-dev.2577+271452d22.zip",
+        "sha256": "23f0c4a4f789b6e1a82861bc14ea80652ba1d75784fcca55e74d50be24cf60e9",
+        "version": "0.14.0-dev.2577+271452d22"
+      },
+      "aarch64-windows": {
+        "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.14.0-dev.2577+271452d22.zip",
+        "sha256": "3563af9bf14a8e510c02c7858320db712348557b71a7d9844d8a960363207518",
+        "version": "0.14.0-dev.2577+271452d22"
+      }
+    }
+  },
+  "2024.11.0-mach": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "19e0b3673fd16609f7ce504faadb1c988270c2ed7cb250a7a9cb74beb22a4c23",
+      "version": "2024.11.0-mach"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "034d395256d9f8b9f4e9fb07bc3428336b5138853dc2d518898fa0fa8fab434f",
+      "version": "2024.11.0-mach"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "7be6abdebfa970c6138d165b348d0464e84f16f531e71cb20c0e052fae1d8c8d",
+      "version": "2024.11.0-mach"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.14.0-dev.2577+271452d22.tar.xz",
+      "sha256": "cafbc9b83e624d8e7e55c41991c2c8d33b52d25661d94c27f236fb622ce168e4",
+      "version": "2024.11.0-mach"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.14.0-dev.2577+271452d22.zip",
+      "sha256": "23f0c4a4f789b6e1a82861bc14ea80652ba1d75784fcca55e74d50be24cf60e9",
+      "version": "2024.11.0-mach"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.14.0-dev.2577+271452d22.zip",
+      "sha256": "3563af9bf14a8e510c02c7858320db712348557b71a7d9844d8a960363207518",
+      "version": "2024.11.0-mach"
+    }
+  },
+  "2024.10.0-mach": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.14.0-dev.1911+3bf89f55c.tar.xz",
+      "sha256": "07dab7e71d61465bebed305d2c8bfae53c5f3b9422dd8e481f1b04bf3812c54b",
+      "version": "2024.10.0-mach"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.14.0-dev.1911+3bf89f55c.tar.xz",
+      "sha256": "fde79992e2f60d8a9155cf0d177c7c84db2a5729f716419660fc75f5d1ed2a95",
+      "version": "2024.10.0-mach"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.14.0-dev.1911+3bf89f55c.tar.xz",
+      "sha256": "73347307b8fcc4d5aab92b7c39f41740ae7b8ee2a82912aecb8cbbf7b6f899fd",
+      "version": "2024.10.0-mach"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.14.0-dev.1911+3bf89f55c.tar.xz",
+      "sha256": "d37e7c596b0bb86e3160eb0f25c8951d7f31ed78dd3f127c701fa9ff95b49298",
+      "version": "2024.10.0-mach"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.14.0-dev.1911+3bf89f55c.zip",
+      "sha256": "10141d62ecdc41784cf24912dbcdc4fbafd8cac7b3818c7fe3ea4d1ab9bccfc5",
+      "version": "2024.10.0-mach"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.14.0-dev.1911+3bf89f55c.zip",
+      "sha256": "9a600ae56d40782f174204f4715bf6f3eadf536146dc794bbbd9a662b2dae70b",
+      "version": "2024.10.0-mach"
+    }
+  },
+  "0.4.0-mach": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "7de18dfc05fc989629311727470f22af9e9e75cb52997c333938eef666e4396e",
+      "version": "0.4.0-mach"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "fef4c33cc8b2c9af1caf47df98786c6bc049dd70ec6c05c794a3273b2937801b",
+      "version": "0.4.0-mach"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "351bcaa1b43db30dc24fb7f34dc598fd7ee4d571f164a4e9bc6dac6f6e6e3c56",
+      "version": "0.4.0-mach"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "20b9602db87482a1b03ca61acaac6acc17e6e3dc2e46d3521430a6aac3e8c4ef",
+      "version": "0.4.0-mach"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.13.0-dev.351+64ef45eb0.zip",
+      "sha256": "7be394a9fa1e131ecd948cd0137a72fcde18afdca7c4420333057974dfee5b7d",
+      "version": "0.4.0-mach"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.13.0-dev.351+64ef45eb0.zip",
+      "sha256": "d2b2d5a61258222467e0de8615675e2e66e184dc36c142adcf628246c97636a4",
+      "version": "0.4.0-mach"
+    }
+  },
+  "2024.5.0-mach": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "7de18dfc05fc989629311727470f22af9e9e75cb52997c333938eef666e4396e",
+      "version": "2024.5.0-mach"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "fef4c33cc8b2c9af1caf47df98786c6bc049dd70ec6c05c794a3273b2937801b",
+      "version": "2024.5.0-mach"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "351bcaa1b43db30dc24fb7f34dc598fd7ee4d571f164a4e9bc6dac6f6e6e3c56",
+      "version": "2024.5.0-mach"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.13.0-dev.351+64ef45eb0.tar.xz",
+      "sha256": "20b9602db87482a1b03ca61acaac6acc17e6e3dc2e46d3521430a6aac3e8c4ef",
+      "version": "2024.5.0-mach"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.13.0-dev.351+64ef45eb0.zip",
+      "sha256": "7be394a9fa1e131ecd948cd0137a72fcde18afdca7c4420333057974dfee5b7d",
+      "version": "2024.5.0-mach"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.13.0-dev.351+64ef45eb0.zip",
+      "sha256": "d2b2d5a61258222467e0de8615675e2e66e184dc36c142adcf628246c97636a4",
+      "version": "2024.5.0-mach"
+    }
+  },
+  "2024.3.0-mach": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.12.0-dev.3180+83e578a18.tar.xz",
+      "sha256": "3d2fe9d76e0bc72430d142cde671fc4f99919aad451d3582121b2746abb5791f",
+      "version": "2024.3.0-mach"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.12.0-dev.3180+83e578a18.tar.xz",
+      "sha256": "c3d455129203fc5ebab77bf9ab4580f15a60f7d5a4a856ef9a1dc80aae856c02",
+      "version": "2024.3.0-mach"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.12.0-dev.3180+83e578a18.tar.xz",
+      "sha256": "66dd365aee3569e71940eb6fb2d47466f04b5ecb430aee74b9624b42ce17d6f6",
+      "version": "2024.3.0-mach"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.12.0-dev.3180+83e578a18.tar.xz",
+      "sha256": "6b4f85c6f5bdc0a9e05ef7d1f49d437c36d8a63d30dba152c83740c0547e38e4",
+      "version": "2024.3.0-mach"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.12.0-dev.3180+83e578a18.zip",
+      "sha256": "471acf6a4ea582720664159b0a2df8b32f1029d6681f80b7354cbb3c3d84b1e8",
+      "version": "2024.3.0-mach"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.12.0-dev.3180+83e578a18.zip",
+      "sha256": "e48fd79741afff7567394ca53a90d75c8a4b6d36c7c76e701ec172a303db4b5e",
+      "version": "2024.3.0-mach"
+    }
+  },
+  "0.3.0-mach": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "1d40ebfec0e72db3fa666e9a997841fd96a704e3b1fc84391dfd7366bf443899",
+      "version": "0.3.0-mach"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "46d0fe89a0357b9f54ea5b15526db04926a9209b871b6d0abd4c7da1cc65acee",
+      "version": "0.3.0-mach"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "4c450d5817da7914b27be2147f9740ebdf186cc933ae87ddb2a8eaa130d02d57",
+      "version": "0.3.0-mach"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "98957f7dce0331cd8e605a703ee29432ef2f8a5117da5e4ed3b1a80923c46fe3",
+      "version": "0.3.0-mach"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.12.0-dev.2063+804cee3b9.zip",
+      "sha256": "8dc5ecd7a0871d1d024e50fffdb51f0aef96c7023d9a935c598610a51f3c725c",
+      "version": "0.3.0-mach"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.12.0-dev.2063+804cee3b9.zip",
+      "sha256": "299d5455cbb4a2370a6675a79f32b01956ffbdda8d70bb78e8a1671940ecd971",
+      "version": "0.3.0-mach"
+    }
+  },
+  "2024.1.0-mach": {
+    "x86_64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-x86_64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "1d40ebfec0e72db3fa666e9a997841fd96a704e3b1fc84391dfd7366bf443899",
+      "version": "2024.1.0-mach"
+    },
+    "aarch64-darwin": {
+      "url": "https://pkg.machengine.org/zig/zig-macos-aarch64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "46d0fe89a0357b9f54ea5b15526db04926a9209b871b6d0abd4c7da1cc65acee",
+      "version": "2024.1.0-mach"
+    },
+    "x86_64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-x86_64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "4c450d5817da7914b27be2147f9740ebdf186cc933ae87ddb2a8eaa130d02d57",
+      "version": "2024.1.0-mach"
+    },
+    "aarch64-linux": {
+      "url": "https://pkg.machengine.org/zig/zig-linux-aarch64-0.12.0-dev.2063+804cee3b9.tar.xz",
+      "sha256": "98957f7dce0331cd8e605a703ee29432ef2f8a5117da5e4ed3b1a80923c46fe3",
+      "version": "2024.1.0-mach"
+    },
+    "x86_64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.12.0-dev.2063+804cee3b9.zip",
+      "sha256": "8dc5ecd7a0871d1d024e50fffdb51f0aef96c7023d9a935c598610a51f3c725c",
+      "version": "2024.1.0-mach"
+    },
+    "aarch64-windows": {
+      "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.12.0-dev.2063+804cee3b9.zip",
+      "sha256": "299d5455cbb4a2370a6675a79f32b01956ffbdda8d70bb78e8a1671940ecd971",
+      "version": "2024.1.0-mach"
     }
   }
 }

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.75+03123916e.tar.xz",
-        "version": "0.15.0-dev.75+03123916e",
-        "sha256": "bd2f795de422ddac78d27cf3d26c29b840f9de2c7c2ead3158ae757de53d50bb"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "version": "0.15.0-dev.77+aa8aa6625",
+        "sha256": "98c78ee83514bcf55b0bff3cb30516123d86c23ca2a5a49e0d5c0119dcbd88fb"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.75+03123916e.tar.xz",
-        "version": "0.15.0-dev.75+03123916e",
-        "sha256": "f95ed95a5c8a8df3b04c259a8a301e149735891cb16a3559a20f12bc3971f7ef"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "version": "0.15.0-dev.77+aa8aa6625",
+        "sha256": "2669cf5980229c5bed244dc8b17f3d630ef28a83ce9171b4a678874afdfc9792"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.75+03123916e.tar.xz",
-        "version": "0.15.0-dev.75+03123916e",
-        "sha256": "eaf524ed2355b975e3cb1ef1c9ee512bb768be3fbc07eeb60a1b4ede0dd077d2"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "version": "0.15.0-dev.77+aa8aa6625",
+        "sha256": "95134bdb9cf3ba3797881557add39b0cb6dac430d0c8ac5615f9e1b5163ba673"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.75+03123916e.tar.xz",
-        "version": "0.15.0-dev.75+03123916e",
-        "sha256": "cdcc28220443f1bd184cc2a45b2740e4b86eb78fc912a81443ad9a4c07ad6424"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "version": "0.15.0-dev.77+aa8aa6625",
+        "sha256": "823f98609eabee6386d02280962c0e9f1f55297d76f9ffa7b059e3f5bbb1fede"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.75+03123916e.zip",
-        "sha256": "62ea284df8fb712ebedda50e8fef92148ba572253b5f79e42872fc95f68414c4",
-        "version": "0.15.0-dev.75+03123916e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.77+aa8aa6625.zip",
+        "sha256": "1cd3baf0ce5022a928c71594c4e10cae8b5c90f4bdc957258cc925aa0a0b4d5d",
+        "version": "0.15.0-dev.77+aa8aa6625"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.75+03123916e.zip",
-        "sha256": "e37d5a887b90dfd435609247ebe802c1740bda2a001a39b07403026e666c47e4",
-        "version": "0.15.0-dev.75+03123916e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.77+aa8aa6625.zip",
+        "sha256": "5b3c118831c3a01ecb6cb543ccfbb675ad27ffec30c9d96c68343f4b1207c064",
+        "version": "0.15.0-dev.77+aa8aa6625"
       }
     },
     "2021-02-20": {
@@ -23671,6 +23671,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.75+03123916e.zip",
         "sha256": "e37d5a887b90dfd435609247ebe802c1740bda2a001a39b07403026e666c47e4",
         "version": "0.15.0-dev.75+03123916e"
+      }
+    },
+    "2025-03-21": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "sha256": "95134bdb9cf3ba3797881557add39b0cb6dac430d0c8ac5615f9e1b5163ba673",
+        "version": "0.15.0-dev.77+aa8aa6625"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "sha256": "823f98609eabee6386d02280962c0e9f1f55297d76f9ffa7b059e3f5bbb1fede",
+        "version": "0.15.0-dev.77+aa8aa6625"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "sha256": "98c78ee83514bcf55b0bff3cb30516123d86c23ca2a5a49e0d5c0119dcbd88fb",
+        "version": "0.15.0-dev.77+aa8aa6625"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.77+aa8aa6625.tar.xz",
+        "sha256": "2669cf5980229c5bed244dc8b17f3d630ef28a83ce9171b4a678874afdfc9792",
+        "version": "0.15.0-dev.77+aa8aa6625"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.77+aa8aa6625.zip",
+        "sha256": "1cd3baf0ce5022a928c71594c4e10cae8b5c90f4bdc957258cc925aa0a0b4d5d",
+        "version": "0.15.0-dev.77+aa8aa6625"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.77+aa8aa6625.zip",
+        "sha256": "5b3c118831c3a01ecb6cb543ccfbb675ad27ffec30c9d96c68343f4b1207c064",
+        "version": "0.15.0-dev.77+aa8aa6625"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3356+5e20e9b44.tar.xz",
-        "version": "0.14.0-dev.3356+5e20e9b44",
-        "sha256": "8a9990bb129ad499974f08735ef05ab98ecdd2836c1d5f89ec7d83b557b7065d"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "version": "0.14.0-dev.3357+c44f4501e",
+        "sha256": "bdf171adc573a0ea3d3812f099348b364219acbc9dee198f9523c37dae4a5b3a"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3356+5e20e9b44.tar.xz",
-        "version": "0.14.0-dev.3356+5e20e9b44",
-        "sha256": "68bf48239ed7187864ed79a4e71faceb5cc14aeb13d0a532eee9a96a400928d2"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "version": "0.14.0-dev.3357+c44f4501e",
+        "sha256": "ba8b640ff57bdbb5203bdb1d4873d56935f285ff904734ab9af0ab44d396af0c"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3356+5e20e9b44.tar.xz",
-        "version": "0.14.0-dev.3356+5e20e9b44",
-        "sha256": "834f6982e0c88d9880ae4e8d5d6b8e82ad71a71b8c2a887b59ce4be46bc0b41f"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "version": "0.14.0-dev.3357+c44f4501e",
+        "sha256": "377562c74475516caadb553d903669764acfe1277047b596c41151432444ef0c"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3356+5e20e9b44.tar.xz",
-        "version": "0.14.0-dev.3356+5e20e9b44",
-        "sha256": "dafce5104658fe4274febcf81cf8f26758b451dc9e076e261ef0d61128ac0b93"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "version": "0.14.0-dev.3357+c44f4501e",
+        "sha256": "3e59b7c0d3282428d48f7434966bd2d4c7e95f12daa5612d659797ba89181984"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3356+5e20e9b44.zip",
-        "sha256": "255cffdec67bab18bee539022644a85398148997e3d6a0978e128b16636b24fc",
-        "version": "0.14.0-dev.3356+5e20e9b44"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3357+c44f4501e.zip",
+        "sha256": "3510ae244767accb76bcccbfc82d96a541b5421587e023d7d4f6966f2b678554",
+        "version": "0.14.0-dev.3357+c44f4501e"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3356+5e20e9b44.zip",
-        "sha256": "f30da30619c0c937db61456bc30e05a4c84b50529cb6ae1994f89c076a339e70",
-        "version": "0.14.0-dev.3356+5e20e9b44"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3357+c44f4501e.zip",
+        "sha256": "89a5e587bd0c5676ab67da0453e29ba757abae7240b73f003155550b44074738",
+        "version": "0.14.0-dev.3357+c44f4501e"
       }
     },
     "2021-02-20": {
@@ -23095,6 +23095,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3356+5e20e9b44.zip",
         "sha256": "f30da30619c0c937db61456bc30e05a4c84b50529cb6ae1994f89c076a339e70",
         "version": "0.14.0-dev.3356+5e20e9b44"
+      }
+    },
+    "2025-02-25": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "sha256": "377562c74475516caadb553d903669764acfe1277047b596c41151432444ef0c",
+        "version": "0.14.0-dev.3357+c44f4501e"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "sha256": "3e59b7c0d3282428d48f7434966bd2d4c7e95f12daa5612d659797ba89181984",
+        "version": "0.14.0-dev.3357+c44f4501e"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "sha256": "bdf171adc573a0ea3d3812f099348b364219acbc9dee198f9523c37dae4a5b3a",
+        "version": "0.14.0-dev.3357+c44f4501e"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3357+c44f4501e.tar.xz",
+        "sha256": "ba8b640ff57bdbb5203bdb1d4873d56935f285ff904734ab9af0ab44d396af0c",
+        "version": "0.14.0-dev.3357+c44f4501e"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3357+c44f4501e.zip",
+        "sha256": "3510ae244767accb76bcccbfc82d96a541b5421587e023d7d4f6966f2b678554",
+        "version": "0.14.0-dev.3357+c44f4501e"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3357+c44f4501e.zip",
+        "sha256": "89a5e587bd0c5676ab67da0453e29ba757abae7240b73f003155550b44074738",
+        "version": "0.14.0-dev.3357+c44f4501e"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "version": "0.15.0-dev.112+6b6dc1cd3",
-        "sha256": "06b38e677eb5bfa9445fc1eed699eb5d0d827485b23da0c0fdfa04cb99156209"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.117+1408288b9.tar.xz",
+        "version": "0.15.0-dev.117+1408288b9",
+        "sha256": "c57f29bbd353e3925411e87ae870ffb465bc12cd254893b0ce4a0cdbe85cea98"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "version": "0.15.0-dev.112+6b6dc1cd3",
-        "sha256": "cccbe2ce0de3a29e842235091f7e89ca7d0ce4e58bf310c12cdd662df7fe73d4"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.117+1408288b9.tar.xz",
+        "version": "0.15.0-dev.117+1408288b9",
+        "sha256": "d9dd5beadd457d23c45b6ca0fe73b6adac08ad67b45a803092f915236114a35a"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "version": "0.15.0-dev.112+6b6dc1cd3",
-        "sha256": "b588f4cf42d524dfdef3d036b728487f28fdbda564bf092cf6ced5715019a216"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.117+1408288b9.tar.xz",
+        "version": "0.15.0-dev.117+1408288b9",
+        "sha256": "c6affa64640e8df9c857ef74de90834f1818b035485b38f5ea3ad2fda308cba7"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "version": "0.15.0-dev.112+6b6dc1cd3",
-        "sha256": "d591362a632d313e0be7fc358c48f6db6d1cf219c84f146351b543a8340e0f0a"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.117+1408288b9.tar.xz",
+        "version": "0.15.0-dev.117+1408288b9",
+        "sha256": "89a16d3cf80c0b97c7273a78c39478f150ab87a6aec6cb9968524cda6676c742"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.112+6b6dc1cd3.zip",
-        "sha256": "45fc0e903a70616503a358357664cdbd8b292a197763ad3cb8698e9a17864fd4",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.117+1408288b9.zip",
+        "sha256": "e2ff725c1d63f44d411c3822cf814fa84bfa51c94758ce33c008f1213d33e9ef",
+        "version": "0.15.0-dev.117+1408288b9"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.112+6b6dc1cd3.zip",
-        "sha256": "c7d02ecacb2f237fba4227c48473cc8ff604b54f9170e71c8f1a06b22aabf163",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.117+1408288b9.zip",
+        "sha256": "f10d60e7d1841d1aa85d50e35ff08a0ddfbc1fa4d89686e1fe68231422d7d049",
+        "version": "0.15.0-dev.117+1408288b9"
       }
     },
     "2021-02-20": {
@@ -23835,34 +23835,34 @@
     },
     "2025-03-26": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "sha256": "b588f4cf42d524dfdef3d036b728487f28fdbda564bf092cf6ced5715019a216",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.117+1408288b9.tar.xz",
+        "sha256": "c6affa64640e8df9c857ef74de90834f1818b035485b38f5ea3ad2fda308cba7",
+        "version": "0.15.0-dev.117+1408288b9"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "sha256": "d591362a632d313e0be7fc358c48f6db6d1cf219c84f146351b543a8340e0f0a",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.117+1408288b9.tar.xz",
+        "sha256": "89a16d3cf80c0b97c7273a78c39478f150ab87a6aec6cb9968524cda6676c742",
+        "version": "0.15.0-dev.117+1408288b9"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "sha256": "06b38e677eb5bfa9445fc1eed699eb5d0d827485b23da0c0fdfa04cb99156209",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.117+1408288b9.tar.xz",
+        "sha256": "c57f29bbd353e3925411e87ae870ffb465bc12cd254893b0ce4a0cdbe85cea98",
+        "version": "0.15.0-dev.117+1408288b9"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
-        "sha256": "cccbe2ce0de3a29e842235091f7e89ca7d0ce4e58bf310c12cdd662df7fe73d4",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.117+1408288b9.tar.xz",
+        "sha256": "d9dd5beadd457d23c45b6ca0fe73b6adac08ad67b45a803092f915236114a35a",
+        "version": "0.15.0-dev.117+1408288b9"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.112+6b6dc1cd3.zip",
-        "sha256": "45fc0e903a70616503a358357664cdbd8b292a197763ad3cb8698e9a17864fd4",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.117+1408288b9.zip",
+        "sha256": "e2ff725c1d63f44d411c3822cf814fa84bfa51c94758ce33c008f1213d33e9ef",
+        "version": "0.15.0-dev.117+1408288b9"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.112+6b6dc1cd3.zip",
-        "sha256": "c7d02ecacb2f237fba4227c48473cc8ff604b54f9170e71c8f1a06b22aabf163",
-        "version": "0.15.0-dev.112+6b6dc1cd3"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.117+1408288b9.zip",
+        "sha256": "f10d60e7d1841d1aa85d50e35ff08a0ddfbc1fa4d89686e1fe68231422d7d049",
+        "version": "0.15.0-dev.117+1408288b9"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "version": "0.14.0-dev.3460+6d29ef0ba",
-        "sha256": "b5cdecc1a7f633cc1ea5ed852b0f96f0d8fdbad3096bbdc99ba75b6e547234bc"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "version": "0.14.0-dev.3462+edabcf619",
+        "sha256": "599a39881c8fd82b23b659537b859c5a2fd85ebfa275abacddcff26188056795"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "version": "0.14.0-dev.3460+6d29ef0ba",
-        "sha256": "e5536f0f7f716528c3028c67e5c5f1a46673a39ada36cc6ad0a8c9d0d32dd1d4"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "version": "0.14.0-dev.3462+edabcf619",
+        "sha256": "e8ca9a4f002e2ac317fc3ef178b43164890389a7eb2d1a958189e21fef61fc57"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "version": "0.14.0-dev.3460+6d29ef0ba",
-        "sha256": "edc0888cf736bb8dc7ca22e87fe7d7173fd9beaa3aae63be5cdf2bd2155ed6d3"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "version": "0.14.0-dev.3462+edabcf619",
+        "sha256": "769d29b58fd565b2160c7791be5ec09f7a4a69dc34fa86b4f84d85106417e8bc"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "version": "0.14.0-dev.3460+6d29ef0ba",
-        "sha256": "fa0bd7289b2ce2eba261b75a7247700bad5778d366e044d3b310678347ea248b"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "version": "0.14.0-dev.3462+edabcf619",
+        "sha256": "25762a31e6917e4331e9adc4f2757cc7c147fa5b15b89ed9e6a8c563a4360884"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3460+6d29ef0ba.zip",
-        "sha256": "ebf4a66441536f38a7e810e57410af94f785890e81bd63ef6bacecd959e3e138",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3462+edabcf619.zip",
+        "sha256": "15568acd17a8b3214622a372ec3cb15c1151da3278f54da28a083102c61b09a6",
+        "version": "0.14.0-dev.3462+edabcf619"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3460+6d29ef0ba.zip",
-        "sha256": "9c6bc9780f03d2e945d700677d8e67d52c7261f8e0a5d0d2b5d3ff6c03949180",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3462+edabcf619.zip",
+        "sha256": "6245c29a376bd5c3638081047a0fcd45f2cc7cb393078975e8035620cfd507d2",
+        "version": "0.14.0-dev.3462+edabcf619"
       }
     },
     "2021-02-20": {
@@ -23323,34 +23323,34 @@
     },
     "2025-03-04": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "sha256": "edc0888cf736bb8dc7ca22e87fe7d7173fd9beaa3aae63be5cdf2bd2155ed6d3",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "sha256": "769d29b58fd565b2160c7791be5ec09f7a4a69dc34fa86b4f84d85106417e8bc",
+        "version": "0.14.0-dev.3462+edabcf619"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "sha256": "fa0bd7289b2ce2eba261b75a7247700bad5778d366e044d3b310678347ea248b",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "sha256": "25762a31e6917e4331e9adc4f2757cc7c147fa5b15b89ed9e6a8c563a4360884",
+        "version": "0.14.0-dev.3462+edabcf619"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "sha256": "b5cdecc1a7f633cc1ea5ed852b0f96f0d8fdbad3096bbdc99ba75b6e547234bc",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "sha256": "599a39881c8fd82b23b659537b859c5a2fd85ebfa275abacddcff26188056795",
+        "version": "0.14.0-dev.3462+edabcf619"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
-        "sha256": "e5536f0f7f716528c3028c67e5c5f1a46673a39ada36cc6ad0a8c9d0d32dd1d4",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3462+edabcf619.tar.xz",
+        "sha256": "e8ca9a4f002e2ac317fc3ef178b43164890389a7eb2d1a958189e21fef61fc57",
+        "version": "0.14.0-dev.3462+edabcf619"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3460+6d29ef0ba.zip",
-        "sha256": "ebf4a66441536f38a7e810e57410af94f785890e81bd63ef6bacecd959e3e138",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3462+edabcf619.zip",
+        "sha256": "15568acd17a8b3214622a372ec3cb15c1151da3278f54da28a083102c61b09a6",
+        "version": "0.14.0-dev.3462+edabcf619"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3460+6d29ef0ba.zip",
-        "sha256": "9c6bc9780f03d2e945d700677d8e67d52c7261f8e0a5d0d2b5d3ff6c03949180",
-        "version": "0.14.0-dev.3460+6d29ef0ba"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3462+edabcf619.zip",
+        "sha256": "6245c29a376bd5c3638081047a0fcd45f2cc7cb393078975e8035620cfd507d2",
+        "version": "0.14.0-dev.3462+edabcf619"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.171+1b62a2226.tar.xz",
-        "version": "0.15.0-dev.171+1b62a2226",
-        "sha256": "dc102dac855e9dbe9db9f81c1be2da5e1d3b6b180ae140c74e89d5d18a374f78"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
+        "version": "0.15.0-dev.175+896ffe665",
+        "sha256": "2495be5d0af3e5099cbd6212a2e784bc22cee07b1434399b5c5a3e3739599afe"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.171+1b62a2226.tar.xz",
-        "version": "0.15.0-dev.171+1b62a2226",
-        "sha256": "3091a253f5ed8133051074aefd29d72d22a0ae8efb45387565b60512bc7efc44"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
+        "version": "0.15.0-dev.175+896ffe665",
+        "sha256": "b8116410dd7835d4f5f9cfcebb072a741dde4fa425ff12896055b03a9840811b"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.171+1b62a2226.tar.xz",
-        "version": "0.15.0-dev.171+1b62a2226",
-        "sha256": "c6fa8c9f54707542108bfe17a8d56f66357130d5bc419d3f916ae264744b02b1"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
+        "version": "0.15.0-dev.175+896ffe665",
+        "sha256": "e93501022013bc9906fc19ef7fb90c40c351de2bcfdb84ed4af4c6cdccb50cc1"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.171+1b62a2226.tar.xz",
-        "version": "0.15.0-dev.171+1b62a2226",
-        "sha256": "df150689281b1334c093308eaae740c128fad883095b4ab26878bf0ca491d34f"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
+        "version": "0.15.0-dev.175+896ffe665",
+        "sha256": "626912d3b8803144e9f1f590593a6da5675b9ba0940e70f4159efe979f5a5048"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.171+1b62a2226.zip",
-        "sha256": "dcdc7679ba5084822ec979d46f4d8d70bdf6987fb5b0842bef458905076fdbff",
-        "version": "0.15.0-dev.171+1b62a2226"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.175+896ffe665.zip",
+        "sha256": "29aee9ef4f09c458457a92217d03e5aa25b659af3105401f6fd31241647cdc5d",
+        "version": "0.15.0-dev.175+896ffe665"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.171+1b62a2226.zip",
-        "sha256": "4e1225204e968d9bbb7ee8d674444c9d164131878dea1f6cf63224433ca92faf",
-        "version": "0.15.0-dev.171+1b62a2226"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.175+896ffe665.zip",
+        "sha256": "d0a158a548260a114209072e38e9bd9c9cc2eb0e9b88c26236ec1729243955b8",
+        "version": "0.15.0-dev.175+896ffe665"
       }
     },
     "2021-02-20": {
@@ -24055,6 +24055,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.171+1b62a2226.zip",
         "sha256": "4e1225204e968d9bbb7ee8d674444c9d164131878dea1f6cf63224433ca92faf",
         "version": "0.15.0-dev.171+1b62a2226"
+      }
+    },
+    "2025-04-03": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
+        "sha256": "e93501022013bc9906fc19ef7fb90c40c351de2bcfdb84ed4af4c6cdccb50cc1",
+        "version": "0.15.0-dev.175+896ffe665"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
+        "sha256": "626912d3b8803144e9f1f590593a6da5675b9ba0940e70f4159efe979f5a5048",
+        "version": "0.15.0-dev.175+896ffe665"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
+        "sha256": "2495be5d0af3e5099cbd6212a2e784bc22cee07b1434399b5c5a3e3739599afe",
+        "version": "0.15.0-dev.175+896ffe665"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
+        "sha256": "b8116410dd7835d4f5f9cfcebb072a741dde4fa425ff12896055b03a9840811b",
+        "version": "0.15.0-dev.175+896ffe665"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.175+896ffe665.zip",
+        "sha256": "29aee9ef4f09c458457a92217d03e5aa25b659af3105401f6fd31241647cdc5d",
+        "version": "0.15.0-dev.175+896ffe665"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.175+896ffe665.zip",
+        "sha256": "d0a158a548260a114209072e38e9bd9c9cc2eb0e9b88c26236ec1729243955b8",
+        "version": "0.15.0-dev.175+896ffe665"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "version": "0.15.0-dev.97+677b2d62e",
-        "sha256": "fcbfd041fec2afeb9b8074661406543c2108a2872b1ddce8f8403cc7d5297112"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.102+525466b49.tar.xz",
+        "version": "0.15.0-dev.102+525466b49",
+        "sha256": "7c3f5270752473152827f2b475ea610c5878eb491e38558f82b40373f0d8f84c"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "version": "0.15.0-dev.97+677b2d62e",
-        "sha256": "2d9f738b5c91814190d8a54404163f2430ee175c5c60b99e2a60e28d455cfcf0"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.102+525466b49.tar.xz",
+        "version": "0.15.0-dev.102+525466b49",
+        "sha256": "d477f814f0e20d3ea3e3438862982533bc64db8472ed8a35cd5f76adf0e6ae0b"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "version": "0.15.0-dev.97+677b2d62e",
-        "sha256": "f62bd7c43ea88fd27d2a0b4804a2decd48902cf6fab84678a79baad8b756303f"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.102+525466b49.tar.xz",
+        "version": "0.15.0-dev.102+525466b49",
+        "sha256": "db0b3b89f103e9ba04e4db1c9c50f8abd0445f1fd81481cdd79f35aadec34730"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "version": "0.15.0-dev.97+677b2d62e",
-        "sha256": "7d6ff150384bd0f2ac1ade4ae3a82776cf75376fbc406ac9f42ec75dffeda6ae"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.102+525466b49.tar.xz",
+        "version": "0.15.0-dev.102+525466b49",
+        "sha256": "56aab0d9167396c9ae2d536390fa3583ad94d9ecf7392a0363655aedf7184e49"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.97+677b2d62e.zip",
-        "sha256": "6d2dad59fedfcc53d72ef9e1c1f588599116a0bd11b151ac66aebbd567a9f772",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.102+525466b49.zip",
+        "sha256": "950682cacd1b25294f7ac5e6c571e3b592e5ee629300ee8b1fe581203e2105b8",
+        "version": "0.15.0-dev.102+525466b49"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.97+677b2d62e.zip",
-        "sha256": "805bcb21271951d5ac6208311f094f9aaaf70aeea80a551b5364687f84a8530b",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.102+525466b49.zip",
+        "sha256": "3e751b35d7ed25cff7f3df6f7954d7d587df5864fd5ba1151cdaa2db4462e93a",
+        "version": "0.15.0-dev.102+525466b49"
       }
     },
     "2021-02-20": {
@@ -23803,34 +23803,34 @@
     },
     "2025-03-25": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "sha256": "f62bd7c43ea88fd27d2a0b4804a2decd48902cf6fab84678a79baad8b756303f",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.102+525466b49.tar.xz",
+        "sha256": "db0b3b89f103e9ba04e4db1c9c50f8abd0445f1fd81481cdd79f35aadec34730",
+        "version": "0.15.0-dev.102+525466b49"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "sha256": "7d6ff150384bd0f2ac1ade4ae3a82776cf75376fbc406ac9f42ec75dffeda6ae",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.102+525466b49.tar.xz",
+        "sha256": "56aab0d9167396c9ae2d536390fa3583ad94d9ecf7392a0363655aedf7184e49",
+        "version": "0.15.0-dev.102+525466b49"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "sha256": "fcbfd041fec2afeb9b8074661406543c2108a2872b1ddce8f8403cc7d5297112",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.102+525466b49.tar.xz",
+        "sha256": "7c3f5270752473152827f2b475ea610c5878eb491e38558f82b40373f0d8f84c",
+        "version": "0.15.0-dev.102+525466b49"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.97+677b2d62e.tar.xz",
-        "sha256": "2d9f738b5c91814190d8a54404163f2430ee175c5c60b99e2a60e28d455cfcf0",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.102+525466b49.tar.xz",
+        "sha256": "d477f814f0e20d3ea3e3438862982533bc64db8472ed8a35cd5f76adf0e6ae0b",
+        "version": "0.15.0-dev.102+525466b49"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.97+677b2d62e.zip",
-        "sha256": "6d2dad59fedfcc53d72ef9e1c1f588599116a0bd11b151ac66aebbd567a9f772",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.102+525466b49.zip",
+        "sha256": "950682cacd1b25294f7ac5e6c571e3b592e5ee629300ee8b1fe581203e2105b8",
+        "version": "0.15.0-dev.102+525466b49"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.97+677b2d62e.zip",
-        "sha256": "805bcb21271951d5ac6208311f094f9aaaf70aeea80a551b5364687f84a8530b",
-        "version": "0.15.0-dev.97+677b2d62e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.102+525466b49.zip",
+        "sha256": "3e751b35d7ed25cff7f3df6f7954d7d587df5864fd5ba1151cdaa2db4462e93a",
+        "version": "0.15.0-dev.102+525466b49"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "version": "0.15.0-dev.65+074dd4d08",
-        "sha256": "40fb7a8358ad97fdf4f74a2a1d24c77732f3cd6ce4b47f4348821f0381c3d2c9"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.75+03123916e.tar.xz",
+        "version": "0.15.0-dev.75+03123916e",
+        "sha256": "bd2f795de422ddac78d27cf3d26c29b840f9de2c7c2ead3158ae757de53d50bb"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "version": "0.15.0-dev.65+074dd4d08",
-        "sha256": "c10a4df28e80c07964cdaf9ba2b150ee5361141361824c088d348a462a2af9c6"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.75+03123916e.tar.xz",
+        "version": "0.15.0-dev.75+03123916e",
+        "sha256": "f95ed95a5c8a8df3b04c259a8a301e149735891cb16a3559a20f12bc3971f7ef"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "version": "0.15.0-dev.65+074dd4d08",
-        "sha256": "9f0e8b4eb6512b7bd700c1cb40b270c9bc28a1d299be38a48adf4275cb5e32f1"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.75+03123916e.tar.xz",
+        "version": "0.15.0-dev.75+03123916e",
+        "sha256": "eaf524ed2355b975e3cb1ef1c9ee512bb768be3fbc07eeb60a1b4ede0dd077d2"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "version": "0.15.0-dev.65+074dd4d08",
-        "sha256": "d496c4bfb8fc8be28dc644fd20bead3a8374bba15dc70bd3e19086f4c002682c"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.75+03123916e.tar.xz",
+        "version": "0.15.0-dev.75+03123916e",
+        "sha256": "cdcc28220443f1bd184cc2a45b2740e4b86eb78fc912a81443ad9a4c07ad6424"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.65+074dd4d08.zip",
-        "sha256": "4159d976e7d1c415fd7fe3743c408eaf37c10a72944e83b9eabd4c2a7a41e1fb",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.75+03123916e.zip",
+        "sha256": "62ea284df8fb712ebedda50e8fef92148ba572253b5f79e42872fc95f68414c4",
+        "version": "0.15.0-dev.75+03123916e"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.65+074dd4d08.zip",
-        "sha256": "c2d993a8e5ad31336166540eb2a56c75375a4e21e5d6397b790e00c74db29827",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.75+03123916e.zip",
+        "sha256": "e37d5a887b90dfd435609247ebe802c1740bda2a001a39b07403026e666c47e4",
+        "version": "0.15.0-dev.75+03123916e"
       }
     },
     "2021-02-20": {
@@ -23643,34 +23643,34 @@
     },
     "2025-03-19": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "sha256": "9f0e8b4eb6512b7bd700c1cb40b270c9bc28a1d299be38a48adf4275cb5e32f1",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.75+03123916e.tar.xz",
+        "sha256": "eaf524ed2355b975e3cb1ef1c9ee512bb768be3fbc07eeb60a1b4ede0dd077d2",
+        "version": "0.15.0-dev.75+03123916e"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "sha256": "d496c4bfb8fc8be28dc644fd20bead3a8374bba15dc70bd3e19086f4c002682c",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.75+03123916e.tar.xz",
+        "sha256": "cdcc28220443f1bd184cc2a45b2740e4b86eb78fc912a81443ad9a4c07ad6424",
+        "version": "0.15.0-dev.75+03123916e"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "sha256": "40fb7a8358ad97fdf4f74a2a1d24c77732f3cd6ce4b47f4348821f0381c3d2c9",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.75+03123916e.tar.xz",
+        "sha256": "bd2f795de422ddac78d27cf3d26c29b840f9de2c7c2ead3158ae757de53d50bb",
+        "version": "0.15.0-dev.75+03123916e"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
-        "sha256": "c10a4df28e80c07964cdaf9ba2b150ee5361141361824c088d348a462a2af9c6",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.75+03123916e.tar.xz",
+        "sha256": "f95ed95a5c8a8df3b04c259a8a301e149735891cb16a3559a20f12bc3971f7ef",
+        "version": "0.15.0-dev.75+03123916e"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.65+074dd4d08.zip",
-        "sha256": "4159d976e7d1c415fd7fe3743c408eaf37c10a72944e83b9eabd4c2a7a41e1fb",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.75+03123916e.zip",
+        "sha256": "62ea284df8fb712ebedda50e8fef92148ba572253b5f79e42872fc95f68414c4",
+        "version": "0.15.0-dev.75+03123916e"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.65+074dd4d08.zip",
-        "sha256": "c2d993a8e5ad31336166540eb2a56c75375a4e21e5d6397b790e00c74db29827",
-        "version": "0.15.0-dev.65+074dd4d08"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.75+03123916e.zip",
+        "sha256": "e37d5a887b90dfd435609247ebe802c1740bda2a001a39b07403026e666c47e4",
+        "version": "0.15.0-dev.75+03123916e"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3271+bd237bced.tar.xz",
-        "version": "0.14.0-dev.3271+bd237bced",
-        "sha256": "cf86eb71a626fd61a01a5d2a686a5582690ae4e474e880c9b0336dd1fc78de82"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "version": "0.14.0-dev.3280+bbd13ab96",
+        "sha256": "495cbc7c1ba02e8dd08ad9dbab81bda770f555a57d60af8fd5cda7f7037e39b0"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3271+bd237bced.tar.xz",
-        "version": "0.14.0-dev.3271+bd237bced",
-        "sha256": "8749cb2a93d25b40821b730828c1d7e7e5a00a9e4bdee604c3852ba9b82dd5c6"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "version": "0.14.0-dev.3280+bbd13ab96",
+        "sha256": "7830d7c6e89f7a7fe6d9dbf1d47b726e9fa4777b3af21662e60fa980ace5a5dc"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3271+bd237bced.tar.xz",
-        "version": "0.14.0-dev.3271+bd237bced",
-        "sha256": "a6eefda5b92fe1a0d8d26b939ab4bc5972a7718acb3e9869c8f5b39989685881"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "version": "0.14.0-dev.3280+bbd13ab96",
+        "sha256": "9d8c1314e5aa5d74cac3042f85fd3fdb12b71a01129966d977298c45bd758ea8"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3271+bd237bced.tar.xz",
-        "version": "0.14.0-dev.3271+bd237bced",
-        "sha256": "3a4a9f3a30827f18fbc76bb128259d5d11cf1204717bdb2d2d14a5c78336b26d"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "version": "0.14.0-dev.3280+bbd13ab96",
+        "sha256": "e452ae640dc1784ae86bcbbf43280f37b7c9fbd000a58f6939d9cbec32775a65"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3271+bd237bced.zip",
-        "sha256": "3cce380467712e453c277c93bf57470a871998a3304817da860a6aad0ee06181",
-        "version": "0.14.0-dev.3271+bd237bced"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3280+bbd13ab96.zip",
+        "sha256": "97d1b7eb2f95c4bb7a4f04b264b25ba858ed6796672b0b9cc2cd9095f905d14d",
+        "version": "0.14.0-dev.3280+bbd13ab96"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3271+bd237bced.zip",
-        "sha256": "9a8d042ec7db024db002bf8646769b196f6e1c642cc0d77cee3135d7c9a0e332",
-        "version": "0.14.0-dev.3271+bd237bced"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3280+bbd13ab96.zip",
+        "sha256": "11f853a55386052360ebddfad9c7c7977502259adbb13c06bdd897edc855d531",
+        "version": "0.14.0-dev.3280+bbd13ab96"
       }
     },
     "2021-02-20": {
@@ -22967,6 +22967,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3271+bd237bced.zip",
         "sha256": "9a8d042ec7db024db002bf8646769b196f6e1c642cc0d77cee3135d7c9a0e332",
         "version": "0.14.0-dev.3271+bd237bced"
+      }
+    },
+    "2025-02-21": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "sha256": "9d8c1314e5aa5d74cac3042f85fd3fdb12b71a01129966d977298c45bd758ea8",
+        "version": "0.14.0-dev.3280+bbd13ab96"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "sha256": "e452ae640dc1784ae86bcbbf43280f37b7c9fbd000a58f6939d9cbec32775a65",
+        "version": "0.14.0-dev.3280+bbd13ab96"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "sha256": "495cbc7c1ba02e8dd08ad9dbab81bda770f555a57d60af8fd5cda7f7037e39b0",
+        "version": "0.14.0-dev.3280+bbd13ab96"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3280+bbd13ab96.tar.xz",
+        "sha256": "7830d7c6e89f7a7fe6d9dbf1d47b726e9fa4777b3af21662e60fa980ace5a5dc",
+        "version": "0.14.0-dev.3280+bbd13ab96"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3280+bbd13ab96.zip",
+        "sha256": "97d1b7eb2f95c4bb7a4f04b264b25ba858ed6796672b0b9cc2cd9095f905d14d",
+        "version": "0.14.0-dev.3280+bbd13ab96"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3280+bbd13ab96.zip",
+        "sha256": "11f853a55386052360ebddfad9c7c7977502259adbb13c06bdd897edc855d531",
+        "version": "0.14.0-dev.3280+bbd13ab96"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "version": "0.14.0-dev.3328+b6a1fdd3f",
-        "sha256": "6af6988a2c468ee4e0a2171e87c0136ff9abb05ccafa64ec791070d98af05e4e"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "version": "0.14.0-dev.3356+5e20e9b44",
+        "sha256": "8a9990bb129ad499974f08735ef05ab98ecdd2836c1d5f89ec7d83b557b7065d"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "version": "0.14.0-dev.3328+b6a1fdd3f",
-        "sha256": "0b04b94c3ba6ec5989e3f66e0cde545aa876ba8aab56f97ace7f30cf4dbcd3b2"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "version": "0.14.0-dev.3356+5e20e9b44",
+        "sha256": "68bf48239ed7187864ed79a4e71faceb5cc14aeb13d0a532eee9a96a400928d2"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "version": "0.14.0-dev.3328+b6a1fdd3f",
-        "sha256": "752e9243b15c9efe5e00604738af75adcb0ebe0d38b29ff5356ee1cf35d86a66"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "version": "0.14.0-dev.3356+5e20e9b44",
+        "sha256": "834f6982e0c88d9880ae4e8d5d6b8e82ad71a71b8c2a887b59ce4be46bc0b41f"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "version": "0.14.0-dev.3328+b6a1fdd3f",
-        "sha256": "308432a18caa95ca4ee05440660acb352452be28e9df49b6ad3db945f73c8d86"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "version": "0.14.0-dev.3356+5e20e9b44",
+        "sha256": "dafce5104658fe4274febcf81cf8f26758b451dc9e076e261ef0d61128ac0b93"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3328+b6a1fdd3f.zip",
-        "sha256": "4bf786bab9df985cf65f85cfc504778b2646855045ae02570d53203db78f5ef7",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3356+5e20e9b44.zip",
+        "sha256": "255cffdec67bab18bee539022644a85398148997e3d6a0978e128b16636b24fc",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3328+b6a1fdd3f.zip",
-        "sha256": "46b738fa7b1b1b98c93673483de78a491c8f12fef8c2daa628d5eb4df6fdc6ad",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3356+5e20e9b44.zip",
+        "sha256": "f30da30619c0c937db61456bc30e05a4c84b50529cb6ae1994f89c076a339e70",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       }
     },
     "2021-02-20": {
@@ -23067,34 +23067,34 @@
     },
     "2025-02-24": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "sha256": "752e9243b15c9efe5e00604738af75adcb0ebe0d38b29ff5356ee1cf35d86a66",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "sha256": "834f6982e0c88d9880ae4e8d5d6b8e82ad71a71b8c2a887b59ce4be46bc0b41f",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "sha256": "308432a18caa95ca4ee05440660acb352452be28e9df49b6ad3db945f73c8d86",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "sha256": "dafce5104658fe4274febcf81cf8f26758b451dc9e076e261ef0d61128ac0b93",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "sha256": "6af6988a2c468ee4e0a2171e87c0136ff9abb05ccafa64ec791070d98af05e4e",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "sha256": "8a9990bb129ad499974f08735ef05ab98ecdd2836c1d5f89ec7d83b557b7065d",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3328+b6a1fdd3f.tar.xz",
-        "sha256": "0b04b94c3ba6ec5989e3f66e0cde545aa876ba8aab56f97ace7f30cf4dbcd3b2",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3356+5e20e9b44.tar.xz",
+        "sha256": "68bf48239ed7187864ed79a4e71faceb5cc14aeb13d0a532eee9a96a400928d2",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3328+b6a1fdd3f.zip",
-        "sha256": "4bf786bab9df985cf65f85cfc504778b2646855045ae02570d53203db78f5ef7",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3356+5e20e9b44.zip",
+        "sha256": "255cffdec67bab18bee539022644a85398148997e3d6a0978e128b16636b24fc",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3328+b6a1fdd3f.zip",
-        "sha256": "46b738fa7b1b1b98c93673483de78a491c8f12fef8c2daa628d5eb4df6fdc6ad",
-        "version": "0.14.0-dev.3328+b6a1fdd3f"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3356+5e20e9b44.zip",
+        "sha256": "f30da30619c0c937db61456bc30e05a4c84b50529cb6ae1994f89c076a339e70",
+        "version": "0.14.0-dev.3356+5e20e9b44"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3388+e0a955afb.tar.xz",
-        "version": "0.14.0-dev.3388+e0a955afb",
-        "sha256": "a5651f7e9230ea395ce62991093d128690ba4598bc42c3000b6253db7fa2aaa0"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "version": "0.14.0-dev.3427+dea72d15d",
+        "sha256": "5ad6c45488547f4991f9a6aed68f208980fb1f8d637533bba815b2c7343638c5"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3388+e0a955afb.tar.xz",
-        "version": "0.14.0-dev.3388+e0a955afb",
-        "sha256": "e946f1bb9da1f3cc2f113caf9e089b3bb0a1c7f013eb10a6fe8f5e5a5aa0b44d"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "version": "0.14.0-dev.3427+dea72d15d",
+        "sha256": "44999da5d6fb58e22cec1112248d1b28ffde80945883f0c6f21bf8f7418d0070"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3388+e0a955afb.tar.xz",
-        "version": "0.14.0-dev.3388+e0a955afb",
-        "sha256": "6a66d9a59dbaa9e2241cd68c62fa634fe4720f3397afd63f95b8d99f1cc18ae3"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "version": "0.14.0-dev.3427+dea72d15d",
+        "sha256": "2dd381c15a8273e718c7c27c92f6f2b7e452014bc6d1c9792fce071255c647f9"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3388+e0a955afb.tar.xz",
-        "version": "0.14.0-dev.3388+e0a955afb",
-        "sha256": "91d9c0fc2420240030938cf7a2b0f2204615e3d20e792457f23c1ba45594eaa5"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "version": "0.14.0-dev.3427+dea72d15d",
+        "sha256": "5272b151e60e136becd9a5ce7e311fb391e4633a0178c359d68e961d6670c2d8"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3388+e0a955afb.zip",
-        "sha256": "5e0a28529030cb73ae4a1638b99ec5f267844091a6df4fa6d44c57cfb3789aa4",
-        "version": "0.14.0-dev.3388+e0a955afb"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3427+dea72d15d.zip",
+        "sha256": "24d4a0d6274629aee03a34a3f596e7142eb5003ef449c7045e593efb0b29983d",
+        "version": "0.14.0-dev.3427+dea72d15d"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3388+e0a955afb.zip",
-        "sha256": "bca0065d4de29c14900dd5daf7f93a749d1a3897de2e837124a7fcceecbc7e38",
-        "version": "0.14.0-dev.3388+e0a955afb"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3427+dea72d15d.zip",
+        "sha256": "3778a23dadba0fc6edebf8286482a64cc5ecbdaa1f96bbc9eb2d9133d306d1ed",
+        "version": "0.14.0-dev.3427+dea72d15d"
       }
     },
     "2021-02-20": {
@@ -23191,6 +23191,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3388+e0a955afb.zip",
         "sha256": "bca0065d4de29c14900dd5daf7f93a749d1a3897de2e837124a7fcceecbc7e38",
         "version": "0.14.0-dev.3388+e0a955afb"
+      }
+    },
+    "2025-02-28": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "sha256": "2dd381c15a8273e718c7c27c92f6f2b7e452014bc6d1c9792fce071255c647f9",
+        "version": "0.14.0-dev.3427+dea72d15d"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "sha256": "5272b151e60e136becd9a5ce7e311fb391e4633a0178c359d68e961d6670c2d8",
+        "version": "0.14.0-dev.3427+dea72d15d"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "sha256": "5ad6c45488547f4991f9a6aed68f208980fb1f8d637533bba815b2c7343638c5",
+        "version": "0.14.0-dev.3427+dea72d15d"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3427+dea72d15d.tar.xz",
+        "sha256": "44999da5d6fb58e22cec1112248d1b28ffde80945883f0c6f21bf8f7418d0070",
+        "version": "0.14.0-dev.3427+dea72d15d"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3427+dea72d15d.zip",
+        "sha256": "24d4a0d6274629aee03a34a3f596e7142eb5003ef449c7045e593efb0b29983d",
+        "version": "0.14.0-dev.3427+dea72d15d"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3427+dea72d15d.zip",
+        "sha256": "3778a23dadba0fc6edebf8286482a64cc5ecbdaa1f96bbc9eb2d9133d306d1ed",
+        "version": "0.14.0-dev.3427+dea72d15d"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.10+214750fcf.tar.xz",
-        "version": "0.15.0-dev.10+214750fcf",
-        "sha256": "a5e3ddf774e3f08afe5f68b54ab704a5e0d0da45867a4e4d43cb494dc19ed5d4"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "version": "0.15.0-dev.14+21620f3c6",
+        "sha256": "086c3baeb14d8855120ded864bfb22d79fc1040b8df492365564d2024624cbc8"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.10+214750fcf.tar.xz",
-        "version": "0.15.0-dev.10+214750fcf",
-        "sha256": "649e3b12cf7d77b0b444b9c4bb0c4df77cbc4b10b5ad6a0ca8320581538ef318"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "version": "0.15.0-dev.14+21620f3c6",
+        "sha256": "4e8941c0096236342122530c227b5ceb133bf367c99007f50ad6f6ce836e6749"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.10+214750fcf.tar.xz",
-        "version": "0.15.0-dev.10+214750fcf",
-        "sha256": "7347a6e444f5bd83243077af310358d654a20ed305c022fd1d36d8284c1a8301"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "version": "0.15.0-dev.14+21620f3c6",
+        "sha256": "0bf4d1ae8373869e02e112867c25e61c3d6ae320be9b58783dbcd98a4445e0a1"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.10+214750fcf.tar.xz",
-        "version": "0.15.0-dev.10+214750fcf",
-        "sha256": "3c949309a2fc68cf1f26aea88a6544ed64efcd032547973e4e12bf7ab4dba1b0"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "version": "0.15.0-dev.14+21620f3c6",
+        "sha256": "6f6045fb0e7c09c813bff4984536a1a5f5c6cf72672a6817efcc2d70a6b97512"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.10+214750fcf.zip",
-        "sha256": "37c27964350ca4dcb0819632facccb00146b4faea79122fed7a1d1c8b8efce7f",
-        "version": "0.15.0-dev.10+214750fcf"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.14+21620f3c6.zip",
+        "sha256": "771747a7d24b331cfb5f6e62ba166bc9c369bc8e723752b3e48526d875688557",
+        "version": "0.15.0-dev.14+21620f3c6"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.10+214750fcf.zip",
-        "sha256": "1635ab8591ff49a0c12042fb86bf24b567d4dc94213f3671617870883243e845",
-        "version": "0.15.0-dev.10+214750fcf"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.14+21620f3c6.zip",
+        "sha256": "b7802de76750c91692273d87476480ce45dbd5f6e141a9f067ea1ce54234c874",
+        "version": "0.15.0-dev.14+21620f3c6"
       }
     },
     "2021-02-20": {
@@ -23447,6 +23447,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.10+214750fcf.zip",
         "sha256": "1635ab8591ff49a0c12042fb86bf24b567d4dc94213f3671617870883243e845",
         "version": "0.15.0-dev.10+214750fcf"
+      }
+    },
+    "2025-03-09": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "sha256": "0bf4d1ae8373869e02e112867c25e61c3d6ae320be9b58783dbcd98a4445e0a1",
+        "version": "0.15.0-dev.14+21620f3c6"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "sha256": "6f6045fb0e7c09c813bff4984536a1a5f5c6cf72672a6817efcc2d70a6b97512",
+        "version": "0.15.0-dev.14+21620f3c6"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "sha256": "086c3baeb14d8855120ded864bfb22d79fc1040b8df492365564d2024624cbc8",
+        "version": "0.15.0-dev.14+21620f3c6"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
+        "sha256": "4e8941c0096236342122530c227b5ceb133bf367c99007f50ad6f6ce836e6749",
+        "version": "0.15.0-dev.14+21620f3c6"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.14+21620f3c6.zip",
+        "sha256": "771747a7d24b331cfb5f6e62ba166bc9c369bc8e723752b3e48526d875688557",
+        "version": "0.15.0-dev.14+21620f3c6"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.14+21620f3c6.zip",
+        "sha256": "b7802de76750c91692273d87476480ce45dbd5f6e141a9f067ea1ce54234c874",
+        "version": "0.15.0-dev.14+21620f3c6"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3427+dea72d15d.tar.xz",
-        "version": "0.14.0-dev.3427+dea72d15d",
-        "sha256": "5ad6c45488547f4991f9a6aed68f208980fb1f8d637533bba815b2c7343638c5"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "version": "0.14.0-dev.3445+6c3cbb0c8",
+        "sha256": "207db6b07162ff84c36a2eb396de3033fc99e47e7db997c875d3c6bf487c1183"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3427+dea72d15d.tar.xz",
-        "version": "0.14.0-dev.3427+dea72d15d",
-        "sha256": "44999da5d6fb58e22cec1112248d1b28ffde80945883f0c6f21bf8f7418d0070"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "version": "0.14.0-dev.3445+6c3cbb0c8",
+        "sha256": "b62751a7cefa1563c294bb2fe72da5f9e49821d5a22741cec9dcf6c75596a28d"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3427+dea72d15d.tar.xz",
-        "version": "0.14.0-dev.3427+dea72d15d",
-        "sha256": "2dd381c15a8273e718c7c27c92f6f2b7e452014bc6d1c9792fce071255c647f9"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "version": "0.14.0-dev.3445+6c3cbb0c8",
+        "sha256": "ecb634469c90b70dc950f16cf9079c465eb9766d2b4273cb9dcc36e7a0c162a0"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3427+dea72d15d.tar.xz",
-        "version": "0.14.0-dev.3427+dea72d15d",
-        "sha256": "5272b151e60e136becd9a5ce7e311fb391e4633a0178c359d68e961d6670c2d8"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "version": "0.14.0-dev.3445+6c3cbb0c8",
+        "sha256": "cc50b6df0b3a2081ba464da6aee2d73a7030cf0931fd9701ea2b0fe70f2fc65d"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3427+dea72d15d.zip",
-        "sha256": "24d4a0d6274629aee03a34a3f596e7142eb5003ef449c7045e593efb0b29983d",
-        "version": "0.14.0-dev.3427+dea72d15d"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3445+6c3cbb0c8.zip",
+        "sha256": "d07d01c17750cfb669e6ab2acc6297e7a21d33f3a409dfb20d745d78c167c4b6",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3427+dea72d15d.zip",
-        "sha256": "3778a23dadba0fc6edebf8286482a64cc5ecbdaa1f96bbc9eb2d9133d306d1ed",
-        "version": "0.14.0-dev.3427+dea72d15d"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3445+6c3cbb0c8.zip",
+        "sha256": "35438d8b316b19e67d042cba332537479d154bbe92a20cac9adb7b6a9d9d6d12",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
       }
     },
     "2021-02-20": {
@@ -23223,6 +23223,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3427+dea72d15d.zip",
         "sha256": "3778a23dadba0fc6edebf8286482a64cc5ecbdaa1f96bbc9eb2d9133d306d1ed",
         "version": "0.14.0-dev.3427+dea72d15d"
+      }
+    },
+    "2025-03-01": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "sha256": "ecb634469c90b70dc950f16cf9079c465eb9766d2b4273cb9dcc36e7a0c162a0",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "sha256": "cc50b6df0b3a2081ba464da6aee2d73a7030cf0931fd9701ea2b0fe70f2fc65d",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "sha256": "207db6b07162ff84c36a2eb396de3033fc99e47e7db997c875d3c6bf487c1183",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
+        "sha256": "b62751a7cefa1563c294bb2fe72da5f9e49821d5a22741cec9dcf6c75596a28d",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3445+6c3cbb0c8.zip",
+        "sha256": "d07d01c17750cfb669e6ab2acc6297e7a21d33f3a409dfb20d745d78c167c4b6",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3445+6c3cbb0c8.zip",
+        "sha256": "35438d8b316b19e67d042cba332537479d154bbe92a20cac9adb7b6a9d9d6d12",
+        "version": "0.14.0-dev.3445+6c3cbb0c8"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.64+2a4e06bcb.tar.xz",
-        "version": "0.15.0-dev.64+2a4e06bcb",
-        "sha256": "6dcf293c5bed4b20823a59c472634f862338772d3c57c60ba9150bb62ce2d784"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "version": "0.15.0-dev.65+074dd4d08",
+        "sha256": "40fb7a8358ad97fdf4f74a2a1d24c77732f3cd6ce4b47f4348821f0381c3d2c9"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.64+2a4e06bcb.tar.xz",
-        "version": "0.15.0-dev.64+2a4e06bcb",
-        "sha256": "5202440dbe8d63b0c3af04e2ecc7924554e806bf597c717d0a7f242d6c7f8686"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "version": "0.15.0-dev.65+074dd4d08",
+        "sha256": "c10a4df28e80c07964cdaf9ba2b150ee5361141361824c088d348a462a2af9c6"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.64+2a4e06bcb.tar.xz",
-        "version": "0.15.0-dev.64+2a4e06bcb",
-        "sha256": "e0070febba66548fe752e9273df18cebca9e295804d7976f9e27a08a91b9c24e"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "version": "0.15.0-dev.65+074dd4d08",
+        "sha256": "9f0e8b4eb6512b7bd700c1cb40b270c9bc28a1d299be38a48adf4275cb5e32f1"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.64+2a4e06bcb.tar.xz",
-        "version": "0.15.0-dev.64+2a4e06bcb",
-        "sha256": "a982caf087042ea897b4cfe755928402d6f70f46145ebb93d07404b498847ca1"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "version": "0.15.0-dev.65+074dd4d08",
+        "sha256": "d496c4bfb8fc8be28dc644fd20bead3a8374bba15dc70bd3e19086f4c002682c"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.64+2a4e06bcb.zip",
-        "sha256": "8c9db33e5904dc5cd14b56adc689148cf1bdae751317431f2c6b4823016599fb",
-        "version": "0.15.0-dev.64+2a4e06bcb"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.65+074dd4d08.zip",
+        "sha256": "4159d976e7d1c415fd7fe3743c408eaf37c10a72944e83b9eabd4c2a7a41e1fb",
+        "version": "0.15.0-dev.65+074dd4d08"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.64+2a4e06bcb.zip",
-        "sha256": "8a82a460ed1c4cbce4a996cc60320f627a7fd37c528a81cd7cd2a171761d28fe",
-        "version": "0.15.0-dev.64+2a4e06bcb"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.65+074dd4d08.zip",
+        "sha256": "c2d993a8e5ad31336166540eb2a56c75375a4e21e5d6397b790e00c74db29827",
+        "version": "0.15.0-dev.65+074dd4d08"
       }
     },
     "2021-02-20": {
@@ -23639,6 +23639,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.64+2a4e06bcb.zip",
         "sha256": "8a82a460ed1c4cbce4a996cc60320f627a7fd37c528a81cd7cd2a171761d28fe",
         "version": "0.15.0-dev.64+2a4e06bcb"
+      }
+    },
+    "2025-03-19": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "sha256": "9f0e8b4eb6512b7bd700c1cb40b270c9bc28a1d299be38a48adf4275cb5e32f1",
+        "version": "0.15.0-dev.65+074dd4d08"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "sha256": "d496c4bfb8fc8be28dc644fd20bead3a8374bba15dc70bd3e19086f4c002682c",
+        "version": "0.15.0-dev.65+074dd4d08"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "sha256": "40fb7a8358ad97fdf4f74a2a1d24c77732f3cd6ce4b47f4348821f0381c3d2c9",
+        "version": "0.15.0-dev.65+074dd4d08"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.65+074dd4d08.tar.xz",
+        "sha256": "c10a4df28e80c07964cdaf9ba2b150ee5361141361824c088d348a462a2af9c6",
+        "version": "0.15.0-dev.65+074dd4d08"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.65+074dd4d08.zip",
+        "sha256": "4159d976e7d1c415fd7fe3743c408eaf37c10a72944e83b9eabd4c2a7a41e1fb",
+        "version": "0.15.0-dev.65+074dd4d08"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.65+074dd4d08.zip",
+        "sha256": "c2d993a8e5ad31336166540eb2a56c75375a4e21e5d6397b790e00c74db29827",
+        "version": "0.15.0-dev.65+074dd4d08"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3385+055969b10.tar.xz",
-        "version": "0.14.0-dev.3385+055969b10",
-        "sha256": "fa8c7e54993d706bcc4fa392fdf5d2d771c41f960a7df9ea8f8a0f82a4ca6759"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "version": "0.14.0-dev.3388+e0a955afb",
+        "sha256": "a5651f7e9230ea395ce62991093d128690ba4598bc42c3000b6253db7fa2aaa0"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3385+055969b10.tar.xz",
-        "version": "0.14.0-dev.3385+055969b10",
-        "sha256": "69fba5990f86b4afc07f24c1f6641e48adb6537a5c6c221f3be24da489d0493d"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "version": "0.14.0-dev.3388+e0a955afb",
+        "sha256": "e946f1bb9da1f3cc2f113caf9e089b3bb0a1c7f013eb10a6fe8f5e5a5aa0b44d"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3385+055969b10.tar.xz",
-        "version": "0.14.0-dev.3385+055969b10",
-        "sha256": "a008b0ab2bfb716dab2311f98d8009122d422d2c69128e92b54dba52fe8220f9"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "version": "0.14.0-dev.3388+e0a955afb",
+        "sha256": "6a66d9a59dbaa9e2241cd68c62fa634fe4720f3397afd63f95b8d99f1cc18ae3"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3385+055969b10.tar.xz",
-        "version": "0.14.0-dev.3385+055969b10",
-        "sha256": "e212bc077440490049de79bcbeee4cca1dd7e0bb5b569365e7e0338c0e31bec5"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "version": "0.14.0-dev.3388+e0a955afb",
+        "sha256": "91d9c0fc2420240030938cf7a2b0f2204615e3d20e792457f23c1ba45594eaa5"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3385+055969b10.zip",
-        "sha256": "9a8f7bfbf164a6c66bf523105120b3cc86808a11dbbbe7bc33e66f21a2433fff",
-        "version": "0.14.0-dev.3385+055969b10"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3388+e0a955afb.zip",
+        "sha256": "5e0a28529030cb73ae4a1638b99ec5f267844091a6df4fa6d44c57cfb3789aa4",
+        "version": "0.14.0-dev.3388+e0a955afb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3385+055969b10.zip",
-        "sha256": "498ce1501f067658d1cd663e15126320c101a3d11d01ef12aa6b3e9e4e3fcc46",
-        "version": "0.14.0-dev.3385+055969b10"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3388+e0a955afb.zip",
+        "sha256": "bca0065d4de29c14900dd5daf7f93a749d1a3897de2e837124a7fcceecbc7e38",
+        "version": "0.14.0-dev.3388+e0a955afb"
       }
     },
     "2021-02-20": {
@@ -23159,6 +23159,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3385+055969b10.zip",
         "sha256": "498ce1501f067658d1cd663e15126320c101a3d11d01ef12aa6b3e9e4e3fcc46",
         "version": "0.14.0-dev.3385+055969b10"
+      }
+    },
+    "2025-02-27": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "sha256": "6a66d9a59dbaa9e2241cd68c62fa634fe4720f3397afd63f95b8d99f1cc18ae3",
+        "version": "0.14.0-dev.3388+e0a955afb"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "sha256": "91d9c0fc2420240030938cf7a2b0f2204615e3d20e792457f23c1ba45594eaa5",
+        "version": "0.14.0-dev.3388+e0a955afb"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "sha256": "a5651f7e9230ea395ce62991093d128690ba4598bc42c3000b6253db7fa2aaa0",
+        "version": "0.14.0-dev.3388+e0a955afb"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3388+e0a955afb.tar.xz",
+        "sha256": "e946f1bb9da1f3cc2f113caf9e089b3bb0a1c7f013eb10a6fe8f5e5a5aa0b44d",
+        "version": "0.14.0-dev.3388+e0a955afb"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3388+e0a955afb.zip",
+        "sha256": "5e0a28529030cb73ae4a1638b99ec5f267844091a6df4fa6d44c57cfb3789aa4",
+        "version": "0.14.0-dev.3388+e0a955afb"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3388+e0a955afb.zip",
+        "sha256": "bca0065d4de29c14900dd5daf7f93a749d1a3897de2e837124a7fcceecbc7e38",
+        "version": "0.14.0-dev.3388+e0a955afb"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3462+edabcf619.tar.xz",
-        "version": "0.14.0-dev.3462+edabcf619",
-        "sha256": "599a39881c8fd82b23b659537b859c5a2fd85ebfa275abacddcff26188056795"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "version": "0.14.0-dev.3470+711b0fef5",
+        "sha256": "2779f8509e82eaada8c1616ecedd315ff32ecb6ce0e1816dbba0caabeb456d20"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3462+edabcf619.tar.xz",
-        "version": "0.14.0-dev.3462+edabcf619",
-        "sha256": "e8ca9a4f002e2ac317fc3ef178b43164890389a7eb2d1a958189e21fef61fc57"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "version": "0.14.0-dev.3470+711b0fef5",
+        "sha256": "8eab22defba781eb60fd3feae5ba07cf00683657377df52a2987ba51f270025e"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3462+edabcf619.tar.xz",
-        "version": "0.14.0-dev.3462+edabcf619",
-        "sha256": "769d29b58fd565b2160c7791be5ec09f7a4a69dc34fa86b4f84d85106417e8bc"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "version": "0.14.0-dev.3470+711b0fef5",
+        "sha256": "959fcba0ef491701d469a9a6c1290007dc97504b98b5b9d3ad9a4f3c3dce2c97"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3462+edabcf619.tar.xz",
-        "version": "0.14.0-dev.3462+edabcf619",
-        "sha256": "25762a31e6917e4331e9adc4f2757cc7c147fa5b15b89ed9e6a8c563a4360884"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "version": "0.14.0-dev.3470+711b0fef5",
+        "sha256": "cdf5c17192ed78034237a22a1eda5f35a0438ddaaf9c426b0a92dd0f7862bd27"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3462+edabcf619.zip",
-        "sha256": "15568acd17a8b3214622a372ec3cb15c1151da3278f54da28a083102c61b09a6",
-        "version": "0.14.0-dev.3462+edabcf619"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3470+711b0fef5.zip",
+        "sha256": "a9ba488527dcbd49a6c5d71e385b7cb82e65165c656e429a0a5c638c92d3399e",
+        "version": "0.14.0-dev.3470+711b0fef5"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3462+edabcf619.zip",
-        "sha256": "6245c29a376bd5c3638081047a0fcd45f2cc7cb393078975e8035620cfd507d2",
-        "version": "0.14.0-dev.3462+edabcf619"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3470+711b0fef5.zip",
+        "sha256": "4894ca99d5486397714a79380736938176489444bee8b81870f131be5b34f4f6",
+        "version": "0.14.0-dev.3470+711b0fef5"
       }
     },
     "2021-02-20": {
@@ -23352,6 +23352,38 @@
         "sha256": "6245c29a376bd5c3638081047a0fcd45f2cc7cb393078975e8035620cfd507d2",
         "version": "0.14.0-dev.3462+edabcf619"
       }
+    },
+    "2025-03-05": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "sha256": "959fcba0ef491701d469a9a6c1290007dc97504b98b5b9d3ad9a4f3c3dce2c97",
+        "version": "0.14.0-dev.3470+711b0fef5"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "sha256": "cdf5c17192ed78034237a22a1eda5f35a0438ddaaf9c426b0a92dd0f7862bd27",
+        "version": "0.14.0-dev.3470+711b0fef5"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "sha256": "2779f8509e82eaada8c1616ecedd315ff32ecb6ce0e1816dbba0caabeb456d20",
+        "version": "0.14.0-dev.3470+711b0fef5"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3470+711b0fef5.tar.xz",
+        "sha256": "8eab22defba781eb60fd3feae5ba07cf00683657377df52a2987ba51f270025e",
+        "version": "0.14.0-dev.3470+711b0fef5"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3470+711b0fef5.zip",
+        "sha256": "a9ba488527dcbd49a6c5d71e385b7cb82e65165c656e429a0a5c638c92d3399e",
+        "version": "0.14.0-dev.3470+711b0fef5"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3470+711b0fef5.zip",
+        "sha256": "4894ca99d5486397714a79380736938176489444bee8b81870f131be5b34f4f6",
+        "version": "0.14.0-dev.3470+711b0fef5"
+      }
     }
   },
   "0.7.1": {
@@ -23878,6 +23910,38 @@
       "url": "https://ziglang.org/download/0.12.0/zig-windows-aarch64-0.12.0.zip",
       "sha256": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b",
       "version": "0.12.0"
+    }
+  },
+  "0.14.0": {
+    "x86_64-darwin": {
+      "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0.tar.xz",
+      "sha256": "685816166f21f0b8d6fc7aa6a36e91396dcd82ca6556dfbe3e329deffc01fec3",
+      "version": "0.14.0"
+    },
+    "aarch64-darwin": {
+      "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0.tar.xz",
+      "sha256": "b71e4b7c4b4be9953657877f7f9e6f7ee89114c716da7c070f4a238220e95d7e",
+      "version": "0.14.0"
+    },
+    "x86_64-linux": {
+      "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0.tar.xz",
+      "sha256": "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982",
+      "version": "0.14.0"
+    },
+    "aarch64-linux": {
+      "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0.tar.xz",
+      "sha256": "ab64e3ea277f6fc5f3d723dcd95d9ce1ab282c8ed0f431b4de880d30df891e4f",
+      "version": "0.14.0"
+    },
+    "x86_64-windows": {
+      "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0.zip",
+      "sha256": "f53e5f9011ba20bbc3e0e6d0a9441b31eb227a97bac0e7d24172f1b8b27b4371",
+      "version": "0.14.0"
+    },
+    "aarch64-windows": {
+      "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0.zip",
+      "sha256": "03e984383ebb8f85293557cfa9f48ee8698e7c400239570c9ff1aef3bffaf046",
+      "version": "0.14.0"
     }
   }
 }

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "version": "0.15.0-dev.14+21620f3c6",
-        "sha256": "086c3baeb14d8855120ded864bfb22d79fc1040b8df492365564d2024624cbc8"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "version": "0.15.0-dev.23+1eb729b9b",
+        "sha256": "750d6683c2a5de609bfc85966f3e8ba66f0421f8986cd86dab54e99bf363e01d"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "version": "0.15.0-dev.14+21620f3c6",
-        "sha256": "4e8941c0096236342122530c227b5ceb133bf367c99007f50ad6f6ce836e6749"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "version": "0.15.0-dev.23+1eb729b9b",
+        "sha256": "2eb78418e16b3bad09fd8a752cdfb72604d00741121ee71a9dd496e3b90baf83"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "version": "0.15.0-dev.14+21620f3c6",
-        "sha256": "0bf4d1ae8373869e02e112867c25e61c3d6ae320be9b58783dbcd98a4445e0a1"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "version": "0.15.0-dev.23+1eb729b9b",
+        "sha256": "572fddccb1a5d045a2039f57e831eeacd8cbc328630987087b38c0c16197f89c"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "version": "0.15.0-dev.14+21620f3c6",
-        "sha256": "6f6045fb0e7c09c813bff4984536a1a5f5c6cf72672a6817efcc2d70a6b97512"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "version": "0.15.0-dev.23+1eb729b9b",
+        "sha256": "bdf1faa1740299e5051d26561fa229a45576bf5d9586e8afbbb1a1789b28169b"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.14+21620f3c6.zip",
-        "sha256": "771747a7d24b331cfb5f6e62ba166bc9c369bc8e723752b3e48526d875688557",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.23+1eb729b9b.zip",
+        "sha256": "e9dc2b7658adf002c77fb383860c8241ea7964b603377350c72ad94687397e0b",
+        "version": "0.15.0-dev.23+1eb729b9b"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.14+21620f3c6.zip",
-        "sha256": "b7802de76750c91692273d87476480ce45dbd5f6e141a9f067ea1ce54234c874",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.23+1eb729b9b.zip",
+        "sha256": "692404aad186cf2c44b045dbf68a91d77c0cf6b8aa0bd0f0ad4931f38fe09049",
+        "version": "0.15.0-dev.23+1eb729b9b"
       }
     },
     "2021-02-20": {
@@ -23451,34 +23451,34 @@
     },
     "2025-03-09": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "sha256": "0bf4d1ae8373869e02e112867c25e61c3d6ae320be9b58783dbcd98a4445e0a1",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "sha256": "572fddccb1a5d045a2039f57e831eeacd8cbc328630987087b38c0c16197f89c",
+        "version": "0.15.0-dev.23+1eb729b9b"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "sha256": "6f6045fb0e7c09c813bff4984536a1a5f5c6cf72672a6817efcc2d70a6b97512",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "sha256": "bdf1faa1740299e5051d26561fa229a45576bf5d9586e8afbbb1a1789b28169b",
+        "version": "0.15.0-dev.23+1eb729b9b"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "sha256": "086c3baeb14d8855120ded864bfb22d79fc1040b8df492365564d2024624cbc8",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "sha256": "750d6683c2a5de609bfc85966f3e8ba66f0421f8986cd86dab54e99bf363e01d",
+        "version": "0.15.0-dev.23+1eb729b9b"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.14+21620f3c6.tar.xz",
-        "sha256": "4e8941c0096236342122530c227b5ceb133bf367c99007f50ad6f6ce836e6749",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.23+1eb729b9b.tar.xz",
+        "sha256": "2eb78418e16b3bad09fd8a752cdfb72604d00741121ee71a9dd496e3b90baf83",
+        "version": "0.15.0-dev.23+1eb729b9b"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.14+21620f3c6.zip",
-        "sha256": "771747a7d24b331cfb5f6e62ba166bc9c369bc8e723752b3e48526d875688557",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.23+1eb729b9b.zip",
+        "sha256": "e9dc2b7658adf002c77fb383860c8241ea7964b603377350c72ad94687397e0b",
+        "version": "0.15.0-dev.23+1eb729b9b"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.14+21620f3c6.zip",
-        "sha256": "b7802de76750c91692273d87476480ce45dbd5f6e141a9f067ea1ce54234c874",
-        "version": "0.15.0-dev.14+21620f3c6"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.23+1eb729b9b.zip",
+        "sha256": "692404aad186cf2c44b045dbf68a91d77c0cf6b8aa0bd0f0ad4931f38fe09049",
+        "version": "0.15.0-dev.23+1eb729b9b"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "version": "0.14.0-dev.3259+0779e847f",
-        "sha256": "986466e257939871be62dcc5bfab027fb26d0fdeee939c7c80219a162642aab0"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "version": "0.14.0-dev.3267+59dc15fa0",
+        "sha256": "31d00cb8a9b2f60f9bc065a2c3d79732843b33ce51b5b05e30a4d512555a0924"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "version": "0.14.0-dev.3259+0779e847f",
-        "sha256": "9f96a0d61cc5d4c9e9a30a9fa46f705e8545d04955c646d2f558002c0fa5371d"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "version": "0.14.0-dev.3267+59dc15fa0",
+        "sha256": "94d64ab2676478ff90485d37bb2e829a8e009633a5ffd705b8234f4c88efe43c"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "version": "0.14.0-dev.3259+0779e847f",
-        "sha256": "d2200100ad252d5f1a48c8c01f2b5f734d43b74d4de00386ecaf2322a619be50"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "version": "0.14.0-dev.3267+59dc15fa0",
+        "sha256": "7239342c31ab94457eab70ff72486b2e5efaacbb2b652a31aeb9a2a3759eaaa0"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "version": "0.14.0-dev.3259+0779e847f",
-        "sha256": "becf9ad5d83c17c1b607d9b5d4937a81374d41591026331c540b3eb661179ea5"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "version": "0.14.0-dev.3267+59dc15fa0",
+        "sha256": "8b18573bb9a635ad66172e04be78433bac0ce0dfb21bd05906b00bc90e1ef40f"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3259+0779e847f.zip",
-        "sha256": "0ef4266393b60daae625afd285c1d1b3854a8f905a019b3aac04b94cb41c6ef8",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3267+59dc15fa0.zip",
+        "sha256": "6c9855c24e19bcc984970521b7e037bc02145980bfa85921492e6c1dc067ceab",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3259+0779e847f.zip",
-        "sha256": "a7394a8b31ece17eed3734abc5c450a1ace100ead573c6378d121bf2d9ddf51f",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3267+59dc15fa0.zip",
+        "sha256": "95a9e0824561a521411f70149ee7f47e211ce2ac8341ffec4b6478fa2a4df5aa",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       }
     },
     "2021-02-20": {
@@ -22907,34 +22907,34 @@
     },
     "2025-02-19": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "sha256": "d2200100ad252d5f1a48c8c01f2b5f734d43b74d4de00386ecaf2322a619be50",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "sha256": "7239342c31ab94457eab70ff72486b2e5efaacbb2b652a31aeb9a2a3759eaaa0",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "sha256": "becf9ad5d83c17c1b607d9b5d4937a81374d41591026331c540b3eb661179ea5",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "sha256": "8b18573bb9a635ad66172e04be78433bac0ce0dfb21bd05906b00bc90e1ef40f",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "sha256": "986466e257939871be62dcc5bfab027fb26d0fdeee939c7c80219a162642aab0",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "sha256": "31d00cb8a9b2f60f9bc065a2c3d79732843b33ce51b5b05e30a4d512555a0924",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3259+0779e847f.tar.xz",
-        "sha256": "9f96a0d61cc5d4c9e9a30a9fa46f705e8545d04955c646d2f558002c0fa5371d",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3267+59dc15fa0.tar.xz",
+        "sha256": "94d64ab2676478ff90485d37bb2e829a8e009633a5ffd705b8234f4c88efe43c",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3259+0779e847f.zip",
-        "sha256": "0ef4266393b60daae625afd285c1d1b3854a8f905a019b3aac04b94cb41c6ef8",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3267+59dc15fa0.zip",
+        "sha256": "6c9855c24e19bcc984970521b7e037bc02145980bfa85921492e6c1dc067ceab",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3259+0779e847f.zip",
-        "sha256": "a7394a8b31ece17eed3734abc5c450a1ace100ead573c6378d121bf2d9ddf51f",
-        "version": "0.14.0-dev.3259+0779e847f"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3267+59dc15fa0.zip",
+        "sha256": "95a9e0824561a521411f70149ee7f47e211ce2ac8341ffec4b6478fa2a4df5aa",
+        "version": "0.14.0-dev.3267+59dc15fa0"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.151+6e8493daa.tar.xz",
-        "version": "0.15.0-dev.151+6e8493daa",
-        "sha256": "b769e825af9c71e22f2eef41323067a348931f05c25b2dadf7351ada38f80ece"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.155+acfdad858.tar.xz",
+        "version": "0.15.0-dev.155+acfdad858",
+        "sha256": "6246e5a6ee3eea664d3ded0bb19472ed350d5339fe57a86967a0f5bcd4750c1b"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.151+6e8493daa.tar.xz",
-        "version": "0.15.0-dev.151+6e8493daa",
-        "sha256": "66c5c4cc2d74f6c6ec6b9ce5d0c60aad3d4fff97c86179c6952164c989827171"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.155+acfdad858.tar.xz",
+        "version": "0.15.0-dev.155+acfdad858",
+        "sha256": "f1785fb6b67a73b26fd030846ec3052d568a2643256dff11019b76cd6c063663"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.151+6e8493daa.tar.xz",
-        "version": "0.15.0-dev.151+6e8493daa",
-        "sha256": "6c48cebbdaa5562c9275e6e4ed44795b1297eadb5534527a820da6c8fae8619d"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.155+acfdad858.tar.xz",
+        "version": "0.15.0-dev.155+acfdad858",
+        "sha256": "175cf416b9cda6364940b8f58df7146458875ab43061a94641e3acd8e5b48e46"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.151+6e8493daa.tar.xz",
-        "version": "0.15.0-dev.151+6e8493daa",
-        "sha256": "0e19ee189b7906cdb09a98940b3519b2a12cc5d6facebe720cae9fb7cd89e821"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.155+acfdad858.tar.xz",
+        "version": "0.15.0-dev.155+acfdad858",
+        "sha256": "9cf5fbe540ae691eb974e56bd67b7713d62d2087b14af98774396b5649d992e1"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.151+6e8493daa.zip",
-        "sha256": "2c2fbea26ef9d2ab1d210c3da456d91b27f1846a9d14761c38af9ce23a04ea27",
-        "version": "0.15.0-dev.151+6e8493daa"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.155+acfdad858.zip",
+        "sha256": "776ea35cd31c5eeef954f3b0827be0533d7206385243ebff79e34a3413c46192",
+        "version": "0.15.0-dev.155+acfdad858"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.151+6e8493daa.zip",
-        "sha256": "112b600aad9c1403354a896f601785a0914ffa1f0aa07a9493120b92fb2da604",
-        "version": "0.15.0-dev.151+6e8493daa"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.155+acfdad858.zip",
+        "sha256": "7c1567210be7f8218e4462e0b8b391b0bff2a7eaf994eaaf7a20b928871d8e20",
+        "version": "0.15.0-dev.155+acfdad858"
       }
     },
     "2021-02-20": {
@@ -23959,6 +23959,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.151+6e8493daa.zip",
         "sha256": "112b600aad9c1403354a896f601785a0914ffa1f0aa07a9493120b92fb2da604",
         "version": "0.15.0-dev.151+6e8493daa"
+      }
+    },
+    "2025-03-30": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.155+acfdad858.tar.xz",
+        "sha256": "175cf416b9cda6364940b8f58df7146458875ab43061a94641e3acd8e5b48e46",
+        "version": "0.15.0-dev.155+acfdad858"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.155+acfdad858.tar.xz",
+        "sha256": "9cf5fbe540ae691eb974e56bd67b7713d62d2087b14af98774396b5649d992e1",
+        "version": "0.15.0-dev.155+acfdad858"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.155+acfdad858.tar.xz",
+        "sha256": "6246e5a6ee3eea664d3ded0bb19472ed350d5339fe57a86967a0f5bcd4750c1b",
+        "version": "0.15.0-dev.155+acfdad858"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.155+acfdad858.tar.xz",
+        "sha256": "f1785fb6b67a73b26fd030846ec3052d568a2643256dff11019b76cd6c063663",
+        "version": "0.15.0-dev.155+acfdad858"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.155+acfdad858.zip",
+        "sha256": "776ea35cd31c5eeef954f3b0827be0533d7206385243ebff79e34a3413c46192",
+        "version": "0.15.0-dev.155+acfdad858"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.155+acfdad858.zip",
+        "sha256": "7c1567210be7f8218e4462e0b8b391b0bff2a7eaf994eaaf7a20b928871d8e20",
+        "version": "0.15.0-dev.155+acfdad858"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.117+1408288b9.tar.xz",
-        "version": "0.15.0-dev.117+1408288b9",
-        "sha256": "c57f29bbd353e3925411e87ae870ffb465bc12cd254893b0ce4a0cdbe85cea98"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "version": "0.15.0-dev.128+5b4759bd3",
+        "sha256": "53cbbefdd6f9d461c3deff2ffa809bf62d72f51ce45a3f07a35297aad4f99d25"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.117+1408288b9.tar.xz",
-        "version": "0.15.0-dev.117+1408288b9",
-        "sha256": "d9dd5beadd457d23c45b6ca0fe73b6adac08ad67b45a803092f915236114a35a"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "version": "0.15.0-dev.128+5b4759bd3",
+        "sha256": "09131c8de1cf6e8214b6aed37dd3f6101e0a94830de18db1f00f058e85acd5c1"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.117+1408288b9.tar.xz",
-        "version": "0.15.0-dev.117+1408288b9",
-        "sha256": "c6affa64640e8df9c857ef74de90834f1818b035485b38f5ea3ad2fda308cba7"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "version": "0.15.0-dev.128+5b4759bd3",
+        "sha256": "ee49ea3e8bcf622a8069e162f085049a2eba7e98d1ff6b10719ef8117df50bb5"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.117+1408288b9.tar.xz",
-        "version": "0.15.0-dev.117+1408288b9",
-        "sha256": "89a16d3cf80c0b97c7273a78c39478f150ab87a6aec6cb9968524cda6676c742"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "version": "0.15.0-dev.128+5b4759bd3",
+        "sha256": "9610835d376744c5827afe51852b33423b455d773cb847659a2098e824583b2f"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.117+1408288b9.zip",
-        "sha256": "e2ff725c1d63f44d411c3822cf814fa84bfa51c94758ce33c008f1213d33e9ef",
-        "version": "0.15.0-dev.117+1408288b9"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.128+5b4759bd3.zip",
+        "sha256": "0575e5498e637be03301c76072027d0f887f312a9d853ec5a35586766d5f5d1a",
+        "version": "0.15.0-dev.128+5b4759bd3"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.117+1408288b9.zip",
-        "sha256": "f10d60e7d1841d1aa85d50e35ff08a0ddfbc1fa4d89686e1fe68231422d7d049",
-        "version": "0.15.0-dev.117+1408288b9"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.128+5b4759bd3.zip",
+        "sha256": "80ff389423d2b7b53e6615863041670a5ace47ed652979481a3a7a4cbb0de525",
+        "version": "0.15.0-dev.128+5b4759bd3"
       }
     },
     "2021-02-20": {
@@ -23863,6 +23863,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.117+1408288b9.zip",
         "sha256": "f10d60e7d1841d1aa85d50e35ff08a0ddfbc1fa4d89686e1fe68231422d7d049",
         "version": "0.15.0-dev.117+1408288b9"
+      }
+    },
+    "2025-03-27": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "sha256": "ee49ea3e8bcf622a8069e162f085049a2eba7e98d1ff6b10719ef8117df50bb5",
+        "version": "0.15.0-dev.128+5b4759bd3"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "sha256": "9610835d376744c5827afe51852b33423b455d773cb847659a2098e824583b2f",
+        "version": "0.15.0-dev.128+5b4759bd3"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "sha256": "53cbbefdd6f9d461c3deff2ffa809bf62d72f51ce45a3f07a35297aad4f99d25",
+        "version": "0.15.0-dev.128+5b4759bd3"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
+        "sha256": "09131c8de1cf6e8214b6aed37dd3f6101e0a94830de18db1f00f058e85acd5c1",
+        "version": "0.15.0-dev.128+5b4759bd3"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.128+5b4759bd3.zip",
+        "sha256": "0575e5498e637be03301c76072027d0f887f312a9d853ec5a35586766d5f5d1a",
+        "version": "0.15.0-dev.128+5b4759bd3"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.128+5b4759bd3.zip",
+        "sha256": "80ff389423d2b7b53e6615863041670a5ace47ed652979481a3a7a4cbb0de525",
+        "version": "0.15.0-dev.128+5b4759bd3"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "version": "0.15.0-dev.128+5b4759bd3",
-        "sha256": "53cbbefdd6f9d461c3deff2ffa809bf62d72f51ce45a3f07a35297aad4f99d25"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.129+b84db311d.tar.xz",
+        "version": "0.15.0-dev.129+b84db311d",
+        "sha256": "c86f8bc0cd71b00810ed0496cfe08f7d0e2f8806db72ef941f774a50bca8d5f6"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "version": "0.15.0-dev.128+5b4759bd3",
-        "sha256": "09131c8de1cf6e8214b6aed37dd3f6101e0a94830de18db1f00f058e85acd5c1"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.129+b84db311d.tar.xz",
+        "version": "0.15.0-dev.129+b84db311d",
+        "sha256": "02eecf352dba15505994060f6148b39ed100a1cf1839b3377831a2de8217f801"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "version": "0.15.0-dev.128+5b4759bd3",
-        "sha256": "ee49ea3e8bcf622a8069e162f085049a2eba7e98d1ff6b10719ef8117df50bb5"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.129+b84db311d.tar.xz",
+        "version": "0.15.0-dev.129+b84db311d",
+        "sha256": "f620b1ef58b522fd204344d74d5bf2948c3819ffba461b8058dd0c904c850287"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "version": "0.15.0-dev.128+5b4759bd3",
-        "sha256": "9610835d376744c5827afe51852b33423b455d773cb847659a2098e824583b2f"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.129+b84db311d.tar.xz",
+        "version": "0.15.0-dev.129+b84db311d",
+        "sha256": "746bdb923765f571a6e7a435b59d0b4204cdccf1fc95565c9fc6017666d5e6a8"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.128+5b4759bd3.zip",
-        "sha256": "0575e5498e637be03301c76072027d0f887f312a9d853ec5a35586766d5f5d1a",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.129+b84db311d.zip",
+        "sha256": "7ae9b67db695a81f64161fb3c4dcd251535b67d7418c06725dd40004809dc5fe",
+        "version": "0.15.0-dev.129+b84db311d"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.128+5b4759bd3.zip",
-        "sha256": "80ff389423d2b7b53e6615863041670a5ace47ed652979481a3a7a4cbb0de525",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.129+b84db311d.zip",
+        "sha256": "f377c926be3b8b23781a2a3044b897168bfac4b3150ac336f0cc30c3658e3ee0",
+        "version": "0.15.0-dev.129+b84db311d"
       }
     },
     "2021-02-20": {
@@ -23867,34 +23867,34 @@
     },
     "2025-03-27": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "sha256": "ee49ea3e8bcf622a8069e162f085049a2eba7e98d1ff6b10719ef8117df50bb5",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.129+b84db311d.tar.xz",
+        "sha256": "f620b1ef58b522fd204344d74d5bf2948c3819ffba461b8058dd0c904c850287",
+        "version": "0.15.0-dev.129+b84db311d"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "sha256": "9610835d376744c5827afe51852b33423b455d773cb847659a2098e824583b2f",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.129+b84db311d.tar.xz",
+        "sha256": "746bdb923765f571a6e7a435b59d0b4204cdccf1fc95565c9fc6017666d5e6a8",
+        "version": "0.15.0-dev.129+b84db311d"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "sha256": "53cbbefdd6f9d461c3deff2ffa809bf62d72f51ce45a3f07a35297aad4f99d25",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.129+b84db311d.tar.xz",
+        "sha256": "c86f8bc0cd71b00810ed0496cfe08f7d0e2f8806db72ef941f774a50bca8d5f6",
+        "version": "0.15.0-dev.129+b84db311d"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.128+5b4759bd3.tar.xz",
-        "sha256": "09131c8de1cf6e8214b6aed37dd3f6101e0a94830de18db1f00f058e85acd5c1",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.129+b84db311d.tar.xz",
+        "sha256": "02eecf352dba15505994060f6148b39ed100a1cf1839b3377831a2de8217f801",
+        "version": "0.15.0-dev.129+b84db311d"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.128+5b4759bd3.zip",
-        "sha256": "0575e5498e637be03301c76072027d0f887f312a9d853ec5a35586766d5f5d1a",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.129+b84db311d.zip",
+        "sha256": "7ae9b67db695a81f64161fb3c4dcd251535b67d7418c06725dd40004809dc5fe",
+        "version": "0.15.0-dev.129+b84db311d"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.128+5b4759bd3.zip",
-        "sha256": "80ff389423d2b7b53e6615863041670a5ace47ed652979481a3a7a4cbb0de525",
-        "version": "0.15.0-dev.128+5b4759bd3"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.129+b84db311d.zip",
+        "sha256": "f377c926be3b8b23781a2a3044b897168bfac4b3150ac336f0cc30c3658e3ee0",
+        "version": "0.15.0-dev.129+b84db311d"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
-        "version": "0.14.0-dev.3445+6c3cbb0c8",
-        "sha256": "207db6b07162ff84c36a2eb396de3033fc99e47e7db997c875d3c6bf487c1183"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "version": "0.14.0-dev.3446+50b40c962",
+        "sha256": "be56e88cafddaacbe47b5a2dad8b858b6d946523c14e600facb03f185658bb27"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
-        "version": "0.14.0-dev.3445+6c3cbb0c8",
-        "sha256": "b62751a7cefa1563c294bb2fe72da5f9e49821d5a22741cec9dcf6c75596a28d"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "version": "0.14.0-dev.3446+50b40c962",
+        "sha256": "1499978969569c405590a02415150e98c71356a6b9deceb1960cc29b3a385462"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
-        "version": "0.14.0-dev.3445+6c3cbb0c8",
-        "sha256": "ecb634469c90b70dc950f16cf9079c465eb9766d2b4273cb9dcc36e7a0c162a0"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "version": "0.14.0-dev.3446+50b40c962",
+        "sha256": "9364ee45e94ed3d01ee15e7cb71d516c520860a6a7c44e6f809c86fd71359525"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3445+6c3cbb0c8.tar.xz",
-        "version": "0.14.0-dev.3445+6c3cbb0c8",
-        "sha256": "cc50b6df0b3a2081ba464da6aee2d73a7030cf0931fd9701ea2b0fe70f2fc65d"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "version": "0.14.0-dev.3446+50b40c962",
+        "sha256": "1b6a8e9333d4a4017fb4a88013e4ec0fc076b658ada650f189b2bf06f723a5be"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3445+6c3cbb0c8.zip",
-        "sha256": "d07d01c17750cfb669e6ab2acc6297e7a21d33f3a409dfb20d745d78c167c4b6",
-        "version": "0.14.0-dev.3445+6c3cbb0c8"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3446+50b40c962.zip",
+        "sha256": "5c0e086eb8353be276279c45f06fbe36fcf7af6b8415148a659999776e681815",
+        "version": "0.14.0-dev.3446+50b40c962"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3445+6c3cbb0c8.zip",
-        "sha256": "35438d8b316b19e67d042cba332537479d154bbe92a20cac9adb7b6a9d9d6d12",
-        "version": "0.14.0-dev.3445+6c3cbb0c8"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3446+50b40c962.zip",
+        "sha256": "7daa702382c7b02c3dc528e8dd1fd20cdb5b84d79bed091fd23f9e2afd09706a",
+        "version": "0.14.0-dev.3446+50b40c962"
       }
     },
     "2021-02-20": {
@@ -23255,6 +23255,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3445+6c3cbb0c8.zip",
         "sha256": "35438d8b316b19e67d042cba332537479d154bbe92a20cac9adb7b6a9d9d6d12",
         "version": "0.14.0-dev.3445+6c3cbb0c8"
+      }
+    },
+    "2025-03-02": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "sha256": "9364ee45e94ed3d01ee15e7cb71d516c520860a6a7c44e6f809c86fd71359525",
+        "version": "0.14.0-dev.3446+50b40c962"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "sha256": "1b6a8e9333d4a4017fb4a88013e4ec0fc076b658ada650f189b2bf06f723a5be",
+        "version": "0.14.0-dev.3446+50b40c962"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "sha256": "be56e88cafddaacbe47b5a2dad8b858b6d946523c14e600facb03f185658bb27",
+        "version": "0.14.0-dev.3446+50b40c962"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3446+50b40c962.tar.xz",
+        "sha256": "1499978969569c405590a02415150e98c71356a6b9deceb1960cc29b3a385462",
+        "version": "0.14.0-dev.3446+50b40c962"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3446+50b40c962.zip",
+        "sha256": "5c0e086eb8353be276279c45f06fbe36fcf7af6b8415148a659999776e681815",
+        "version": "0.14.0-dev.3446+50b40c962"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3446+50b40c962.zip",
+        "sha256": "7daa702382c7b02c3dc528e8dd1fd20cdb5b84d79bed091fd23f9e2afd09706a",
+        "version": "0.14.0-dev.3446+50b40c962"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.168+b636d56d6.tar.xz",
-        "version": "0.15.0-dev.168+b636d56d6",
-        "sha256": "840e8437687277b4cefc67bd1a7f184c407153eabefca93fe378b9ab3d54f58d"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "version": "0.15.0-dev.169+fa86e09fb",
+        "sha256": "b9232b7b648acfcab61371b24396a71de4c4c66b7f27f8c6ac6c572fa221a30c"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.168+b636d56d6.tar.xz",
-        "version": "0.15.0-dev.168+b636d56d6",
-        "sha256": "6b5b41e6b08dc23391746b920638dc71ac4958c94131f0782d71ce4a1bf5e093"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "version": "0.15.0-dev.169+fa86e09fb",
+        "sha256": "ae0d67e172fc51c25b722486825a50203d1be5e7697638d6337b49b45437c4b5"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.168+b636d56d6.tar.xz",
-        "version": "0.15.0-dev.168+b636d56d6",
-        "sha256": "8d78678fcd0f62d5cac5df5a3eedea19a56ded13a9698aaf8bb7d00b649928d7"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "version": "0.15.0-dev.169+fa86e09fb",
+        "sha256": "da6f02b4c09b560601630a19c84293501d7ed43e7ceb0d1038822454be161a39"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.168+b636d56d6.tar.xz",
-        "version": "0.15.0-dev.168+b636d56d6",
-        "sha256": "847559c797c3f98096cc48409080ef5c98518005e151b9707f90b96a2c6732ad"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "version": "0.15.0-dev.169+fa86e09fb",
+        "sha256": "179c5e665a8b473e6773c0e7cb69cb0aa959f0845f5db8a3d2ec2097f92cd548"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.168+b636d56d6.zip",
-        "sha256": "2965b80393985df171d3e7880fa47b6e3aca0f3e2fad8bdeba72f8db4cdc44b4",
-        "version": "0.15.0-dev.168+b636d56d6"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.169+fa86e09fb.zip",
+        "sha256": "9770abc49e2ffc6698a14343733315016db938abb008f91898c4789a22bcf698",
+        "version": "0.15.0-dev.169+fa86e09fb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.168+b636d56d6.zip",
-        "sha256": "e86edd84e2636378368864304d144a6815341ea9eaa16f36b37d6d13b350d032",
-        "version": "0.15.0-dev.168+b636d56d6"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.169+fa86e09fb.zip",
+        "sha256": "b02411fcf2a681ec97bf385744e86ca23a8b0fc20879cc3883930423d4f408f7",
+        "version": "0.15.0-dev.169+fa86e09fb"
       }
     },
     "2021-02-20": {
@@ -24023,6 +24023,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.168+b636d56d6.zip",
         "sha256": "e86edd84e2636378368864304d144a6815341ea9eaa16f36b37d6d13b350d032",
         "version": "0.15.0-dev.168+b636d56d6"
+      }
+    },
+    "2025-04-02": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "sha256": "da6f02b4c09b560601630a19c84293501d7ed43e7ceb0d1038822454be161a39",
+        "version": "0.15.0-dev.169+fa86e09fb"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "sha256": "179c5e665a8b473e6773c0e7cb69cb0aa959f0845f5db8a3d2ec2097f92cd548",
+        "version": "0.15.0-dev.169+fa86e09fb"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "sha256": "b9232b7b648acfcab61371b24396a71de4c4c66b7f27f8c6ac6c572fa221a30c",
+        "version": "0.15.0-dev.169+fa86e09fb"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.169+fa86e09fb.tar.xz",
+        "sha256": "ae0d67e172fc51c25b722486825a50203d1be5e7697638d6337b49b45437c4b5",
+        "version": "0.15.0-dev.169+fa86e09fb"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.169+fa86e09fb.zip",
+        "sha256": "9770abc49e2ffc6698a14343733315016db938abb008f91898c4789a22bcf698",
+        "version": "0.15.0-dev.169+fa86e09fb"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.169+fa86e09fb.zip",
+        "sha256": "b02411fcf2a681ec97bf385744e86ca23a8b0fc20879cc3883930423d4f408f7",
+        "version": "0.15.0-dev.169+fa86e09fb"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.78+9c9d3931d.tar.xz",
-        "version": "0.15.0-dev.78+9c9d3931d",
-        "sha256": "8f3d6072356406d30478566764285d509a3de163f1306946c173f012f0647316"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.79+9f235a105.tar.xz",
+        "version": "0.15.0-dev.79+9f235a105",
+        "sha256": "538b026619216c1de99d82875a4ae83bdca59229d72e8a12b6850699465978af"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.78+9c9d3931d.tar.xz",
-        "version": "0.15.0-dev.78+9c9d3931d",
-        "sha256": "524cfd040f2230df569200b723329acabd49e94085320b913d09e414939ed233"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.79+9f235a105.tar.xz",
+        "version": "0.15.0-dev.79+9f235a105",
+        "sha256": "5623c2645e4c8d4d90a077daefcffdb2e48c31f29e8e2c00776da686fb311aaf"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.78+9c9d3931d.tar.xz",
-        "version": "0.15.0-dev.78+9c9d3931d",
-        "sha256": "6590f2bd6f815129b3ef7ff13413ec9372f12ff5e6ea81b69e59332b3d521065"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.79+9f235a105.tar.xz",
+        "version": "0.15.0-dev.79+9f235a105",
+        "sha256": "8972343a3be743f5fa715335ae88b345e790a6d5f0a7088cf9b28576cb8da25c"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.78+9c9d3931d.tar.xz",
-        "version": "0.15.0-dev.78+9c9d3931d",
-        "sha256": "6a6cf6b793af38cfeeab66fb74b4fb7cccb25565a9f541a61bbb4926c2b153fd"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.79+9f235a105.tar.xz",
+        "version": "0.15.0-dev.79+9f235a105",
+        "sha256": "3b8d330a6764236117316269fb86e4e072396aa175b4671aa689132b4504b8e9"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.78+9c9d3931d.zip",
-        "sha256": "463703b500434cf5720170bb38afd6b5777c6703a6a97732ccfe8cfd812fe456",
-        "version": "0.15.0-dev.78+9c9d3931d"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.79+9f235a105.zip",
+        "sha256": "3039e41b80044e00fc502639072fa74439a9f4b406a68988ef9ec7fdd73866d5",
+        "version": "0.15.0-dev.79+9f235a105"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.78+9c9d3931d.zip",
-        "sha256": "adc3b7b22df6d5145cd943c5c68bd1b5f81141be70beab6ea6cb830b353de101",
-        "version": "0.15.0-dev.78+9c9d3931d"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.79+9f235a105.zip",
+        "sha256": "215526b7a4de93060d63c5d490330f852453b5bf1df6245e214a7681eda87d13",
+        "version": "0.15.0-dev.79+9f235a105"
       }
     },
     "2021-02-20": {
@@ -23735,6 +23735,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.78+9c9d3931d.zip",
         "sha256": "adc3b7b22df6d5145cd943c5c68bd1b5f81141be70beab6ea6cb830b353de101",
         "version": "0.15.0-dev.78+9c9d3931d"
+      }
+    },
+    "2025-03-23": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.79+9f235a105.tar.xz",
+        "sha256": "8972343a3be743f5fa715335ae88b345e790a6d5f0a7088cf9b28576cb8da25c",
+        "version": "0.15.0-dev.79+9f235a105"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.79+9f235a105.tar.xz",
+        "sha256": "3b8d330a6764236117316269fb86e4e072396aa175b4671aa689132b4504b8e9",
+        "version": "0.15.0-dev.79+9f235a105"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.79+9f235a105.tar.xz",
+        "sha256": "538b026619216c1de99d82875a4ae83bdca59229d72e8a12b6850699465978af",
+        "version": "0.15.0-dev.79+9f235a105"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.79+9f235a105.tar.xz",
+        "sha256": "5623c2645e4c8d4d90a077daefcffdb2e48c31f29e8e2c00776da686fb311aaf",
+        "version": "0.15.0-dev.79+9f235a105"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.79+9f235a105.zip",
+        "sha256": "3039e41b80044e00fc502639072fa74439a9f4b406a68988ef9ec7fdd73866d5",
+        "version": "0.15.0-dev.79+9f235a105"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.79+9f235a105.zip",
+        "sha256": "215526b7a4de93060d63c5d490330f852453b5bf1df6245e214a7681eda87d13",
+        "version": "0.15.0-dev.79+9f235a105"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
-        "version": "0.15.0-dev.175+896ffe665",
-        "sha256": "2495be5d0af3e5099cbd6212a2e784bc22cee07b1434399b5c5a3e3739599afe"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "version": "0.15.0-dev.190+bfbf4badd",
+        "sha256": "8d43bf988c48127232e8896ba3b43b2fb28ef75ebad0fa7ea281907783489f29"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
-        "version": "0.15.0-dev.175+896ffe665",
-        "sha256": "b8116410dd7835d4f5f9cfcebb072a741dde4fa425ff12896055b03a9840811b"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "version": "0.15.0-dev.190+bfbf4badd",
+        "sha256": "f2baa96d581315a75efe1aa20ee853c689d7ca8c1ccb56baf75a77e4cfb22871"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
-        "version": "0.15.0-dev.175+896ffe665",
-        "sha256": "e93501022013bc9906fc19ef7fb90c40c351de2bcfdb84ed4af4c6cdccb50cc1"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "version": "0.15.0-dev.190+bfbf4badd",
+        "sha256": "86c74d0dd121a88529c083f8bbd9cae16afc6185d7425123be75d03591779e83"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
-        "version": "0.15.0-dev.175+896ffe665",
-        "sha256": "626912d3b8803144e9f1f590593a6da5675b9ba0940e70f4159efe979f5a5048"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "version": "0.15.0-dev.190+bfbf4badd",
+        "sha256": "4a3bb62d42872982ce1e5b83104de5677f8c4ada581ad3efcf899285b975c1e9"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.175+896ffe665.zip",
-        "sha256": "29aee9ef4f09c458457a92217d03e5aa25b659af3105401f6fd31241647cdc5d",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.190+bfbf4badd.zip",
+        "sha256": "a7f640f278d2fc4af1b67c4796e9ffc660c8ee7564b6e7dee138b66a0fe6a802",
+        "version": "0.15.0-dev.190+bfbf4badd"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.175+896ffe665.zip",
-        "sha256": "d0a158a548260a114209072e38e9bd9c9cc2eb0e9b88c26236ec1729243955b8",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.190+bfbf4badd.zip",
+        "sha256": "ecd4f608bc807d4390cf0e8348723882ef22e28fb55d753cc296f3ea72ce95f0",
+        "version": "0.15.0-dev.190+bfbf4badd"
       }
     },
     "2021-02-20": {
@@ -24059,34 +24059,34 @@
     },
     "2025-04-03": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
-        "sha256": "e93501022013bc9906fc19ef7fb90c40c351de2bcfdb84ed4af4c6cdccb50cc1",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "sha256": "86c74d0dd121a88529c083f8bbd9cae16afc6185d7425123be75d03591779e83",
+        "version": "0.15.0-dev.190+bfbf4badd"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
-        "sha256": "626912d3b8803144e9f1f590593a6da5675b9ba0940e70f4159efe979f5a5048",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "sha256": "4a3bb62d42872982ce1e5b83104de5677f8c4ada581ad3efcf899285b975c1e9",
+        "version": "0.15.0-dev.190+bfbf4badd"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.175+896ffe665.tar.xz",
-        "sha256": "2495be5d0af3e5099cbd6212a2e784bc22cee07b1434399b5c5a3e3739599afe",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "sha256": "8d43bf988c48127232e8896ba3b43b2fb28ef75ebad0fa7ea281907783489f29",
+        "version": "0.15.0-dev.190+bfbf4badd"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.175+896ffe665.tar.xz",
-        "sha256": "b8116410dd7835d4f5f9cfcebb072a741dde4fa425ff12896055b03a9840811b",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.190+bfbf4badd.tar.xz",
+        "sha256": "f2baa96d581315a75efe1aa20ee853c689d7ca8c1ccb56baf75a77e4cfb22871",
+        "version": "0.15.0-dev.190+bfbf4badd"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.175+896ffe665.zip",
-        "sha256": "29aee9ef4f09c458457a92217d03e5aa25b659af3105401f6fd31241647cdc5d",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.190+bfbf4badd.zip",
+        "sha256": "a7f640f278d2fc4af1b67c4796e9ffc660c8ee7564b6e7dee138b66a0fe6a802",
+        "version": "0.15.0-dev.190+bfbf4badd"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.175+896ffe665.zip",
-        "sha256": "d0a158a548260a114209072e38e9bd9c9cc2eb0e9b88c26236ec1729243955b8",
-        "version": "0.15.0-dev.175+896ffe665"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.190+bfbf4badd.zip",
+        "sha256": "ecd4f608bc807d4390cf0e8348723882ef22e28fb55d753cc296f3ea72ce95f0",
+        "version": "0.15.0-dev.190+bfbf4badd"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.190+bfbf4badd.tar.xz",
-        "version": "0.15.0-dev.190+bfbf4badd",
-        "sha256": "8d43bf988c48127232e8896ba3b43b2fb28ef75ebad0fa7ea281907783489f29"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "version": "0.15.0-dev.197+155b34ba0",
+        "sha256": "1227b8599c069d2fbdfa14c4782944ede1eec4d9a5541996db7f924e1513a52b"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.190+bfbf4badd.tar.xz",
-        "version": "0.15.0-dev.190+bfbf4badd",
-        "sha256": "f2baa96d581315a75efe1aa20ee853c689d7ca8c1ccb56baf75a77e4cfb22871"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "version": "0.15.0-dev.197+155b34ba0",
+        "sha256": "2fc7e0526cad97297fea74f7089410a4fcdb82cf1d3ee27234951f88ebcff788"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.190+bfbf4badd.tar.xz",
-        "version": "0.15.0-dev.190+bfbf4badd",
-        "sha256": "86c74d0dd121a88529c083f8bbd9cae16afc6185d7425123be75d03591779e83"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "version": "0.15.0-dev.197+155b34ba0",
+        "sha256": "45e77e154457b18d56fe0ea3c303eecd02b094995bc343f4a194b4343011f277"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.190+bfbf4badd.tar.xz",
-        "version": "0.15.0-dev.190+bfbf4badd",
-        "sha256": "4a3bb62d42872982ce1e5b83104de5677f8c4ada581ad3efcf899285b975c1e9"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "version": "0.15.0-dev.197+155b34ba0",
+        "sha256": "99b8d75636081065788f4aea55f1dc58a10654794ba3313a74364c4f59fd0dcc"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.190+bfbf4badd.zip",
-        "sha256": "a7f640f278d2fc4af1b67c4796e9ffc660c8ee7564b6e7dee138b66a0fe6a802",
-        "version": "0.15.0-dev.190+bfbf4badd"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.197+155b34ba0.zip",
+        "sha256": "571ebfbe9918253e6e654981de22c3515a965afa1f83eb00732b37ff4088027e",
+        "version": "0.15.0-dev.197+155b34ba0"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.190+bfbf4badd.zip",
-        "sha256": "ecd4f608bc807d4390cf0e8348723882ef22e28fb55d753cc296f3ea72ce95f0",
-        "version": "0.15.0-dev.190+bfbf4badd"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.197+155b34ba0.zip",
+        "sha256": "84552338349f2cccc0d213eb4f3deb4ceded8e17cd3861600848f7e58d31a94b",
+        "version": "0.15.0-dev.197+155b34ba0"
       }
     },
     "2021-02-20": {
@@ -24087,6 +24087,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.190+bfbf4badd.zip",
         "sha256": "ecd4f608bc807d4390cf0e8348723882ef22e28fb55d753cc296f3ea72ce95f0",
         "version": "0.15.0-dev.190+bfbf4badd"
+      }
+    },
+    "2025-04-04": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "sha256": "45e77e154457b18d56fe0ea3c303eecd02b094995bc343f4a194b4343011f277",
+        "version": "0.15.0-dev.197+155b34ba0"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "sha256": "99b8d75636081065788f4aea55f1dc58a10654794ba3313a74364c4f59fd0dcc",
+        "version": "0.15.0-dev.197+155b34ba0"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "sha256": "1227b8599c069d2fbdfa14c4782944ede1eec4d9a5541996db7f924e1513a52b",
+        "version": "0.15.0-dev.197+155b34ba0"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.197+155b34ba0.tar.xz",
+        "sha256": "2fc7e0526cad97297fea74f7089410a4fcdb82cf1d3ee27234951f88ebcff788",
+        "version": "0.15.0-dev.197+155b34ba0"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.197+155b34ba0.zip",
+        "sha256": "571ebfbe9918253e6e654981de22c3515a965afa1f83eb00732b37ff4088027e",
+        "version": "0.15.0-dev.197+155b34ba0"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.197+155b34ba0.zip",
+        "sha256": "84552338349f2cccc0d213eb4f3deb4ceded8e17cd3861600848f7e58d31a94b",
+        "version": "0.15.0-dev.197+155b34ba0"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.155+acfdad858.tar.xz",
-        "version": "0.15.0-dev.155+acfdad858",
-        "sha256": "6246e5a6ee3eea664d3ded0bb19472ed350d5339fe57a86967a0f5bcd4750c1b"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "version": "0.15.0-dev.168+b636d56d6",
+        "sha256": "840e8437687277b4cefc67bd1a7f184c407153eabefca93fe378b9ab3d54f58d"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.155+acfdad858.tar.xz",
-        "version": "0.15.0-dev.155+acfdad858",
-        "sha256": "f1785fb6b67a73b26fd030846ec3052d568a2643256dff11019b76cd6c063663"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "version": "0.15.0-dev.168+b636d56d6",
+        "sha256": "6b5b41e6b08dc23391746b920638dc71ac4958c94131f0782d71ce4a1bf5e093"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.155+acfdad858.tar.xz",
-        "version": "0.15.0-dev.155+acfdad858",
-        "sha256": "175cf416b9cda6364940b8f58df7146458875ab43061a94641e3acd8e5b48e46"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "version": "0.15.0-dev.168+b636d56d6",
+        "sha256": "8d78678fcd0f62d5cac5df5a3eedea19a56ded13a9698aaf8bb7d00b649928d7"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.155+acfdad858.tar.xz",
-        "version": "0.15.0-dev.155+acfdad858",
-        "sha256": "9cf5fbe540ae691eb974e56bd67b7713d62d2087b14af98774396b5649d992e1"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "version": "0.15.0-dev.168+b636d56d6",
+        "sha256": "847559c797c3f98096cc48409080ef5c98518005e151b9707f90b96a2c6732ad"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.155+acfdad858.zip",
-        "sha256": "776ea35cd31c5eeef954f3b0827be0533d7206385243ebff79e34a3413c46192",
-        "version": "0.15.0-dev.155+acfdad858"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.168+b636d56d6.zip",
+        "sha256": "2965b80393985df171d3e7880fa47b6e3aca0f3e2fad8bdeba72f8db4cdc44b4",
+        "version": "0.15.0-dev.168+b636d56d6"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.155+acfdad858.zip",
-        "sha256": "7c1567210be7f8218e4462e0b8b391b0bff2a7eaf994eaaf7a20b928871d8e20",
-        "version": "0.15.0-dev.155+acfdad858"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.168+b636d56d6.zip",
+        "sha256": "e86edd84e2636378368864304d144a6815341ea9eaa16f36b37d6d13b350d032",
+        "version": "0.15.0-dev.168+b636d56d6"
       }
     },
     "2021-02-20": {
@@ -23991,6 +23991,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.155+acfdad858.zip",
         "sha256": "7c1567210be7f8218e4462e0b8b391b0bff2a7eaf994eaaf7a20b928871d8e20",
         "version": "0.15.0-dev.155+acfdad858"
+      }
+    },
+    "2025-04-01": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "sha256": "8d78678fcd0f62d5cac5df5a3eedea19a56ded13a9698aaf8bb7d00b649928d7",
+        "version": "0.15.0-dev.168+b636d56d6"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "sha256": "847559c797c3f98096cc48409080ef5c98518005e151b9707f90b96a2c6732ad",
+        "version": "0.15.0-dev.168+b636d56d6"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "sha256": "840e8437687277b4cefc67bd1a7f184c407153eabefca93fe378b9ab3d54f58d",
+        "version": "0.15.0-dev.168+b636d56d6"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.168+b636d56d6.tar.xz",
+        "sha256": "6b5b41e6b08dc23391746b920638dc71ac4958c94131f0782d71ce4a1bf5e093",
+        "version": "0.15.0-dev.168+b636d56d6"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.168+b636d56d6.zip",
+        "sha256": "2965b80393985df171d3e7880fa47b6e3aca0f3e2fad8bdeba72f8db4cdc44b4",
+        "version": "0.15.0-dev.168+b636d56d6"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.168+b636d56d6.zip",
+        "sha256": "e86edd84e2636378368864304d144a6815341ea9eaa16f36b37d6d13b350d032",
+        "version": "0.15.0-dev.168+b636d56d6"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.102+525466b49.tar.xz",
-        "version": "0.15.0-dev.102+525466b49",
-        "sha256": "7c3f5270752473152827f2b475ea610c5878eb491e38558f82b40373f0d8f84c"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "version": "0.15.0-dev.112+6b6dc1cd3",
+        "sha256": "06b38e677eb5bfa9445fc1eed699eb5d0d827485b23da0c0fdfa04cb99156209"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.102+525466b49.tar.xz",
-        "version": "0.15.0-dev.102+525466b49",
-        "sha256": "d477f814f0e20d3ea3e3438862982533bc64db8472ed8a35cd5f76adf0e6ae0b"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "version": "0.15.0-dev.112+6b6dc1cd3",
+        "sha256": "cccbe2ce0de3a29e842235091f7e89ca7d0ce4e58bf310c12cdd662df7fe73d4"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.102+525466b49.tar.xz",
-        "version": "0.15.0-dev.102+525466b49",
-        "sha256": "db0b3b89f103e9ba04e4db1c9c50f8abd0445f1fd81481cdd79f35aadec34730"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "version": "0.15.0-dev.112+6b6dc1cd3",
+        "sha256": "b588f4cf42d524dfdef3d036b728487f28fdbda564bf092cf6ced5715019a216"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.102+525466b49.tar.xz",
-        "version": "0.15.0-dev.102+525466b49",
-        "sha256": "56aab0d9167396c9ae2d536390fa3583ad94d9ecf7392a0363655aedf7184e49"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "version": "0.15.0-dev.112+6b6dc1cd3",
+        "sha256": "d591362a632d313e0be7fc358c48f6db6d1cf219c84f146351b543a8340e0f0a"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.102+525466b49.zip",
-        "sha256": "950682cacd1b25294f7ac5e6c571e3b592e5ee629300ee8b1fe581203e2105b8",
-        "version": "0.15.0-dev.102+525466b49"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.112+6b6dc1cd3.zip",
+        "sha256": "45fc0e903a70616503a358357664cdbd8b292a197763ad3cb8698e9a17864fd4",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.102+525466b49.zip",
-        "sha256": "3e751b35d7ed25cff7f3df6f7954d7d587df5864fd5ba1151cdaa2db4462e93a",
-        "version": "0.15.0-dev.102+525466b49"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.112+6b6dc1cd3.zip",
+        "sha256": "c7d02ecacb2f237fba4227c48473cc8ff604b54f9170e71c8f1a06b22aabf163",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
       }
     },
     "2021-02-20": {
@@ -23831,6 +23831,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.102+525466b49.zip",
         "sha256": "3e751b35d7ed25cff7f3df6f7954d7d587df5864fd5ba1151cdaa2db4462e93a",
         "version": "0.15.0-dev.102+525466b49"
+      }
+    },
+    "2025-03-26": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "sha256": "b588f4cf42d524dfdef3d036b728487f28fdbda564bf092cf6ced5715019a216",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "sha256": "d591362a632d313e0be7fc358c48f6db6d1cf219c84f146351b543a8340e0f0a",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "sha256": "06b38e677eb5bfa9445fc1eed699eb5d0d827485b23da0c0fdfa04cb99156209",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.112+6b6dc1cd3.tar.xz",
+        "sha256": "cccbe2ce0de3a29e842235091f7e89ca7d0ce4e58bf310c12cdd662df7fe73d4",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.112+6b6dc1cd3.zip",
+        "sha256": "45fc0e903a70616503a358357664cdbd8b292a197763ad3cb8698e9a17864fd4",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.112+6b6dc1cd3.zip",
+        "sha256": "c7d02ecacb2f237fba4227c48473cc8ff604b54f9170e71c8f1a06b22aabf163",
+        "version": "0.15.0-dev.112+6b6dc1cd3"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "version": "0.14.0-dev.3241+55c46870b",
-        "sha256": "5d4c941b100d7eaf29013b5ca4b5fb9c93065562aa39ac16a69ae71263c27d2f"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "version": "0.14.0-dev.3258+d2e70ef84",
+        "sha256": "855fa28928a79eebb70b29595ab9952bdf3ab258ef3e266ac2e366d815936d9b"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "version": "0.14.0-dev.3241+55c46870b",
-        "sha256": "4d9bac0eb5ddd04ba3aca15ccc0ea78fc399ea4bc591e16818e37b32ef0bc9c3"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "version": "0.14.0-dev.3258+d2e70ef84",
+        "sha256": "2a28fdb35d18223e03509ed7974f4b7c78a2100de4a1dde3442fe80b7eb09afa"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "version": "0.14.0-dev.3241+55c46870b",
-        "sha256": "231610d0b39f35c379b7ae72848338ee454d38713de3b4040c621cbe70805177"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "version": "0.14.0-dev.3258+d2e70ef84",
+        "sha256": "435fcfa402cddc249e1e727a417ab1ade26c643a13222edb14b5261a64a707f7"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "version": "0.14.0-dev.3241+55c46870b",
-        "sha256": "d34c0e18310c8478a909ceb599f04e64d5c2f738b1459d86754e7cb453980e3d"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "version": "0.14.0-dev.3258+d2e70ef84",
+        "sha256": "4a461ad310f043008b8c9b2bbf0480078d2acbc90d37418e3f4d5eb48092ea80"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3241+55c46870b.zip",
-        "sha256": "26645ed33241df452708b70f5995f6df8ce38b5ad57e5eed6e790cb3db7e9665",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3258+d2e70ef84.zip",
+        "sha256": "87c47cba48ca80411306d91952ff68c6df3e31e56644c28ead0d730ab3ff30cb",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3241+55c46870b.zip",
-        "sha256": "2eee633006271122e44bc6f06886002397d1ad34b0b515e0a0de23b5b74818c7",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3258+d2e70ef84.zip",
+        "sha256": "79569b3523783cb3a3c603dd02f01190b6b93879885cf3f176857f3efb7d91f1",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       }
     },
     "2021-02-20": {
@@ -22875,34 +22875,34 @@
     },
     "2025-02-18": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "sha256": "231610d0b39f35c379b7ae72848338ee454d38713de3b4040c621cbe70805177",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "sha256": "435fcfa402cddc249e1e727a417ab1ade26c643a13222edb14b5261a64a707f7",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "sha256": "d34c0e18310c8478a909ceb599f04e64d5c2f738b1459d86754e7cb453980e3d",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "sha256": "4a461ad310f043008b8c9b2bbf0480078d2acbc90d37418e3f4d5eb48092ea80",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "sha256": "5d4c941b100d7eaf29013b5ca4b5fb9c93065562aa39ac16a69ae71263c27d2f",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "sha256": "855fa28928a79eebb70b29595ab9952bdf3ab258ef3e266ac2e366d815936d9b",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3241+55c46870b.tar.xz",
-        "sha256": "4d9bac0eb5ddd04ba3aca15ccc0ea78fc399ea4bc591e16818e37b32ef0bc9c3",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3258+d2e70ef84.tar.xz",
+        "sha256": "2a28fdb35d18223e03509ed7974f4b7c78a2100de4a1dde3442fe80b7eb09afa",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3241+55c46870b.zip",
-        "sha256": "26645ed33241df452708b70f5995f6df8ce38b5ad57e5eed6e790cb3db7e9665",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3258+d2e70ef84.zip",
+        "sha256": "87c47cba48ca80411306d91952ff68c6df3e31e56644c28ead0d730ab3ff30cb",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3241+55c46870b.zip",
-        "sha256": "2eee633006271122e44bc6f06886002397d1ad34b0b515e0a0de23b5b74818c7",
-        "version": "0.14.0-dev.3241+55c46870b"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3258+d2e70ef84.zip",
+        "sha256": "79569b3523783cb3a3c603dd02f01190b6b93879885cf3f176857f3efb7d91f1",
+        "version": "0.14.0-dev.3258+d2e70ef84"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "version": "0.14.0-dev.3451+d8d2aa9af",
-        "sha256": "a9b2aeaea89a93bb4d5f390007259b776d53b4537e4a060a07f4e6b530f1f38c"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "version": "0.14.0-dev.3456+00a8742bb",
+        "sha256": "853ab877925ca967cf0fa9a85414aec9636db3a02c590e2615f49d0f336cab95"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "version": "0.14.0-dev.3451+d8d2aa9af",
-        "sha256": "941f2f0892af4ed794253527320fc80f41dbb6168a119648ca0401eeda9205b6"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "version": "0.14.0-dev.3456+00a8742bb",
+        "sha256": "014ef001d6e2118429f747daaed006f21ca255bdfbae8200a65341fb68a0ddd7"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "version": "0.14.0-dev.3451+d8d2aa9af",
-        "sha256": "bac6171f60244e7f95f6565210f295786a5da2469b3e1b2a6d2e133745c7d6ab"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "version": "0.14.0-dev.3456+00a8742bb",
+        "sha256": "7f13822fde5c5cfb7f9c92e9828864c38b15e565f0736dbabad2eb0913a3b1c3"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "version": "0.14.0-dev.3451+d8d2aa9af",
-        "sha256": "fdc3c7139a3fb5f7e6d3c2b9c8174c85c6c5ebe1d04f9b8467f1cebcd31421aa"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "version": "0.14.0-dev.3456+00a8742bb",
+        "sha256": "91dcb5a019e0a8d53aff25353957df5e385f7c244c625cb1768d6fda5a5d13c9"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3451+d8d2aa9af.zip",
-        "sha256": "a451bb0ec577db5ee7f6b24d27a211b0a9064d5998a0066c80760eab079229fa",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3456+00a8742bb.zip",
+        "sha256": "ebecf8e27061bdd7496a1c866da2c8e0d6b38db181d3ebff37fd16b8eae4030f",
+        "version": "0.14.0-dev.3456+00a8742bb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3451+d8d2aa9af.zip",
-        "sha256": "b5614dc4a5d68a64254fd826165837dfa8dbf30bf91168e74cfcdd53301d5a4f",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3456+00a8742bb.zip",
+        "sha256": "be5eedd46c98e34e5aaf8518bd09817631f56e300506af3b37332acffb522de1",
+        "version": "0.14.0-dev.3456+00a8742bb"
       }
     },
     "2021-02-20": {
@@ -23291,34 +23291,34 @@
     },
     "2025-03-03": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "sha256": "bac6171f60244e7f95f6565210f295786a5da2469b3e1b2a6d2e133745c7d6ab",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "sha256": "7f13822fde5c5cfb7f9c92e9828864c38b15e565f0736dbabad2eb0913a3b1c3",
+        "version": "0.14.0-dev.3456+00a8742bb"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "sha256": "fdc3c7139a3fb5f7e6d3c2b9c8174c85c6c5ebe1d04f9b8467f1cebcd31421aa",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "sha256": "91dcb5a019e0a8d53aff25353957df5e385f7c244c625cb1768d6fda5a5d13c9",
+        "version": "0.14.0-dev.3456+00a8742bb"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "sha256": "a9b2aeaea89a93bb4d5f390007259b776d53b4537e4a060a07f4e6b530f1f38c",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "sha256": "853ab877925ca967cf0fa9a85414aec9636db3a02c590e2615f49d0f336cab95",
+        "version": "0.14.0-dev.3456+00a8742bb"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3451+d8d2aa9af.tar.xz",
-        "sha256": "941f2f0892af4ed794253527320fc80f41dbb6168a119648ca0401eeda9205b6",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3456+00a8742bb.tar.xz",
+        "sha256": "014ef001d6e2118429f747daaed006f21ca255bdfbae8200a65341fb68a0ddd7",
+        "version": "0.14.0-dev.3456+00a8742bb"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3451+d8d2aa9af.zip",
-        "sha256": "a451bb0ec577db5ee7f6b24d27a211b0a9064d5998a0066c80760eab079229fa",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3456+00a8742bb.zip",
+        "sha256": "ebecf8e27061bdd7496a1c866da2c8e0d6b38db181d3ebff37fd16b8eae4030f",
+        "version": "0.14.0-dev.3456+00a8742bb"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3451+d8d2aa9af.zip",
-        "sha256": "b5614dc4a5d68a64254fd826165837dfa8dbf30bf91168e74cfcdd53301d5a4f",
-        "version": "0.14.0-dev.3451+d8d2aa9af"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3456+00a8742bb.zip",
+        "sha256": "be5eedd46c98e34e5aaf8518bd09817631f56e300506af3b37332acffb522de1",
+        "version": "0.14.0-dev.3456+00a8742bb"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.197+155b34ba0.tar.xz",
-        "version": "0.15.0-dev.197+155b34ba0",
-        "sha256": "1227b8599c069d2fbdfa14c4782944ede1eec4d9a5541996db7f924e1513a52b"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "version": "0.15.0-dev.203+84c9cee50",
+        "sha256": "e9178061022d73667803b7d98bf8ce538870fb44fc6be6a58edbb3b18c992df7"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.197+155b34ba0.tar.xz",
-        "version": "0.15.0-dev.197+155b34ba0",
-        "sha256": "2fc7e0526cad97297fea74f7089410a4fcdb82cf1d3ee27234951f88ebcff788"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "version": "0.15.0-dev.203+84c9cee50",
+        "sha256": "be9dc5ab99b4457bdbfdab68430089b0011747a783607512a79f6d6adbaf8c0b"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.197+155b34ba0.tar.xz",
-        "version": "0.15.0-dev.197+155b34ba0",
-        "sha256": "45e77e154457b18d56fe0ea3c303eecd02b094995bc343f4a194b4343011f277"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "version": "0.15.0-dev.203+84c9cee50",
+        "sha256": "e397a249ff7c8da5efe5b8ca71a7e0a073ea419b908c155622f733ce066bafea"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.197+155b34ba0.tar.xz",
-        "version": "0.15.0-dev.197+155b34ba0",
-        "sha256": "99b8d75636081065788f4aea55f1dc58a10654794ba3313a74364c4f59fd0dcc"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "version": "0.15.0-dev.203+84c9cee50",
+        "sha256": "acfe49afb0f2b90b9491cf85e5b7b90d366268cb6e750c264babaede21b0eac1"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.197+155b34ba0.zip",
-        "sha256": "571ebfbe9918253e6e654981de22c3515a965afa1f83eb00732b37ff4088027e",
-        "version": "0.15.0-dev.197+155b34ba0"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.203+84c9cee50.zip",
+        "sha256": "a84847e701479746b30e96df9696f35f24e47a3b267974d80a358e322d02b1fd",
+        "version": "0.15.0-dev.203+84c9cee50"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.197+155b34ba0.zip",
-        "sha256": "84552338349f2cccc0d213eb4f3deb4ceded8e17cd3861600848f7e58d31a94b",
-        "version": "0.15.0-dev.197+155b34ba0"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.203+84c9cee50.zip",
+        "sha256": "e9908d46e1f782edda2b5b0e3f147003d17a26f014c278a301e3cd67ee5c3969",
+        "version": "0.15.0-dev.203+84c9cee50"
       }
     },
     "2021-02-20": {
@@ -24119,6 +24119,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.197+155b34ba0.zip",
         "sha256": "84552338349f2cccc0d213eb4f3deb4ceded8e17cd3861600848f7e58d31a94b",
         "version": "0.15.0-dev.197+155b34ba0"
+      }
+    },
+    "2025-04-05": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "sha256": "e397a249ff7c8da5efe5b8ca71a7e0a073ea419b908c155622f733ce066bafea",
+        "version": "0.15.0-dev.203+84c9cee50"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "sha256": "acfe49afb0f2b90b9491cf85e5b7b90d366268cb6e750c264babaede21b0eac1",
+        "version": "0.15.0-dev.203+84c9cee50"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "sha256": "e9178061022d73667803b7d98bf8ce538870fb44fc6be6a58edbb3b18c992df7",
+        "version": "0.15.0-dev.203+84c9cee50"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.203+84c9cee50.tar.xz",
+        "sha256": "be9dc5ab99b4457bdbfdab68430089b0011747a783607512a79f6d6adbaf8c0b",
+        "version": "0.15.0-dev.203+84c9cee50"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.203+84c9cee50.zip",
+        "sha256": "a84847e701479746b30e96df9696f35f24e47a3b267974d80a358e322d02b1fd",
+        "version": "0.15.0-dev.203+84c9cee50"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.203+84c9cee50.zip",
+        "sha256": "e9908d46e1f782edda2b5b0e3f147003d17a26f014c278a301e3cd67ee5c3969",
+        "version": "0.15.0-dev.203+84c9cee50"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3280+bbd13ab96.tar.xz",
-        "version": "0.14.0-dev.3280+bbd13ab96",
-        "sha256": "495cbc7c1ba02e8dd08ad9dbab81bda770f555a57d60af8fd5cda7f7037e39b0"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "version": "0.14.0-dev.3286+05d8b565a",
+        "sha256": "5293449f628e82a47067ec2711d299086d83d0459418a1cdee7a26173b08f1ee"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3280+bbd13ab96.tar.xz",
-        "version": "0.14.0-dev.3280+bbd13ab96",
-        "sha256": "7830d7c6e89f7a7fe6d9dbf1d47b726e9fa4777b3af21662e60fa980ace5a5dc"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "version": "0.14.0-dev.3286+05d8b565a",
+        "sha256": "4f5551a4fc91de5f7dca13eaba2da0b57919c5099d80b7babe906af6320638e0"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3280+bbd13ab96.tar.xz",
-        "version": "0.14.0-dev.3280+bbd13ab96",
-        "sha256": "9d8c1314e5aa5d74cac3042f85fd3fdb12b71a01129966d977298c45bd758ea8"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "version": "0.14.0-dev.3286+05d8b565a",
+        "sha256": "264384888a1a6b0bd84a435281f9afbcdd99e4bf5bb909037457ebea1bfd76ce"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3280+bbd13ab96.tar.xz",
-        "version": "0.14.0-dev.3280+bbd13ab96",
-        "sha256": "e452ae640dc1784ae86bcbbf43280f37b7c9fbd000a58f6939d9cbec32775a65"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "version": "0.14.0-dev.3286+05d8b565a",
+        "sha256": "8ab842fa321c4f20c4adfc67aaac949b227466e1f17e005ad1df6df860c6f939"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3280+bbd13ab96.zip",
-        "sha256": "97d1b7eb2f95c4bb7a4f04b264b25ba858ed6796672b0b9cc2cd9095f905d14d",
-        "version": "0.14.0-dev.3280+bbd13ab96"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3286+05d8b565a.zip",
+        "sha256": "a7496a379b0c27b45b9c1bbd2bfc59cf41005175532f4eafc09a1ea6628c70ce",
+        "version": "0.14.0-dev.3286+05d8b565a"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3280+bbd13ab96.zip",
-        "sha256": "11f853a55386052360ebddfad9c7c7977502259adbb13c06bdd897edc855d531",
-        "version": "0.14.0-dev.3280+bbd13ab96"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3286+05d8b565a.zip",
+        "sha256": "bba104ce7365a5d7ee6a31da081e3440008f6fad9a073a1a11dce9e2f1ba7e23",
+        "version": "0.14.0-dev.3286+05d8b565a"
       }
     },
     "2021-02-20": {
@@ -22999,6 +22999,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3280+bbd13ab96.zip",
         "sha256": "11f853a55386052360ebddfad9c7c7977502259adbb13c06bdd897edc855d531",
         "version": "0.14.0-dev.3280+bbd13ab96"
+      }
+    },
+    "2025-02-22": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "sha256": "264384888a1a6b0bd84a435281f9afbcdd99e4bf5bb909037457ebea1bfd76ce",
+        "version": "0.14.0-dev.3286+05d8b565a"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "sha256": "8ab842fa321c4f20c4adfc67aaac949b227466e1f17e005ad1df6df860c6f939",
+        "version": "0.14.0-dev.3286+05d8b565a"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "sha256": "5293449f628e82a47067ec2711d299086d83d0459418a1cdee7a26173b08f1ee",
+        "version": "0.14.0-dev.3286+05d8b565a"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3286+05d8b565a.tar.xz",
+        "sha256": "4f5551a4fc91de5f7dca13eaba2da0b57919c5099d80b7babe906af6320638e0",
+        "version": "0.14.0-dev.3286+05d8b565a"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3286+05d8b565a.zip",
+        "sha256": "a7496a379b0c27b45b9c1bbd2bfc59cf41005175532f4eafc09a1ea6628c70ce",
+        "version": "0.14.0-dev.3286+05d8b565a"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3286+05d8b565a.zip",
+        "sha256": "bba104ce7365a5d7ee6a31da081e3440008f6fad9a073a1a11dce9e2f1ba7e23",
+        "version": "0.14.0-dev.3286+05d8b565a"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.129+b84db311d.tar.xz",
-        "version": "0.15.0-dev.129+b84db311d",
-        "sha256": "c86f8bc0cd71b00810ed0496cfe08f7d0e2f8806db72ef941f774a50bca8d5f6"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
+        "version": "0.15.0-dev.132+263ba3461",
+        "sha256": "ba59af2c5ad033ddb03930c1868c5ff4d47e4d8de50d3ea7235d2a93a42cf959"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.129+b84db311d.tar.xz",
-        "version": "0.15.0-dev.129+b84db311d",
-        "sha256": "02eecf352dba15505994060f6148b39ed100a1cf1839b3377831a2de8217f801"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
+        "version": "0.15.0-dev.132+263ba3461",
+        "sha256": "a941072db4b95ae223aec7ed25eb16b0720663c459266eea3c01b2aae9a69281"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.129+b84db311d.tar.xz",
-        "version": "0.15.0-dev.129+b84db311d",
-        "sha256": "f620b1ef58b522fd204344d74d5bf2948c3819ffba461b8058dd0c904c850287"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
+        "version": "0.15.0-dev.132+263ba3461",
+        "sha256": "add829b6a95c1196ee141ab3d8c96686f87ceb7358ae5cbd87136bfbde4951cc"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.129+b84db311d.tar.xz",
-        "version": "0.15.0-dev.129+b84db311d",
-        "sha256": "746bdb923765f571a6e7a435b59d0b4204cdccf1fc95565c9fc6017666d5e6a8"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
+        "version": "0.15.0-dev.132+263ba3461",
+        "sha256": "ab1fac877416a1e1203a6efeef764a3e7a35c07a928700ff4fa88ce6c56f41cf"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.129+b84db311d.zip",
-        "sha256": "7ae9b67db695a81f64161fb3c4dcd251535b67d7418c06725dd40004809dc5fe",
-        "version": "0.15.0-dev.129+b84db311d"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.132+263ba3461.zip",
+        "sha256": "37953bbf179efaa30f4f62e6cbba9f686268cd05a714744f32975bfc9fe9e29e",
+        "version": "0.15.0-dev.132+263ba3461"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.129+b84db311d.zip",
-        "sha256": "f377c926be3b8b23781a2a3044b897168bfac4b3150ac336f0cc30c3658e3ee0",
-        "version": "0.15.0-dev.129+b84db311d"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.132+263ba3461.zip",
+        "sha256": "a9d7679c9a02b3a81cc0fa461932b9d687a79f53f2fdb5b3954a3b507ef98f5f",
+        "version": "0.15.0-dev.132+263ba3461"
       }
     },
     "2021-02-20": {
@@ -23895,6 +23895,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.129+b84db311d.zip",
         "sha256": "f377c926be3b8b23781a2a3044b897168bfac4b3150ac336f0cc30c3658e3ee0",
         "version": "0.15.0-dev.129+b84db311d"
+      }
+    },
+    "2025-03-28": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
+        "sha256": "add829b6a95c1196ee141ab3d8c96686f87ceb7358ae5cbd87136bfbde4951cc",
+        "version": "0.15.0-dev.132+263ba3461"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
+        "sha256": "ab1fac877416a1e1203a6efeef764a3e7a35c07a928700ff4fa88ce6c56f41cf",
+        "version": "0.15.0-dev.132+263ba3461"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.132+263ba3461.tar.xz",
+        "sha256": "ba59af2c5ad033ddb03930c1868c5ff4d47e4d8de50d3ea7235d2a93a42cf959",
+        "version": "0.15.0-dev.132+263ba3461"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.132+263ba3461.tar.xz",
+        "sha256": "a941072db4b95ae223aec7ed25eb16b0720663c459266eea3c01b2aae9a69281",
+        "version": "0.15.0-dev.132+263ba3461"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.132+263ba3461.zip",
+        "sha256": "37953bbf179efaa30f4f62e6cbba9f686268cd05a714744f32975bfc9fe9e29e",
+        "version": "0.15.0-dev.132+263ba3461"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.132+263ba3461.zip",
+        "sha256": "a9d7679c9a02b3a81cc0fa461932b9d687a79f53f2fdb5b3954a3b507ef98f5f",
+        "version": "0.15.0-dev.132+263ba3461"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3456+00a8742bb.tar.xz",
-        "version": "0.14.0-dev.3456+00a8742bb",
-        "sha256": "853ab877925ca967cf0fa9a85414aec9636db3a02c590e2615f49d0f336cab95"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "version": "0.14.0-dev.3460+6d29ef0ba",
+        "sha256": "b5cdecc1a7f633cc1ea5ed852b0f96f0d8fdbad3096bbdc99ba75b6e547234bc"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3456+00a8742bb.tar.xz",
-        "version": "0.14.0-dev.3456+00a8742bb",
-        "sha256": "014ef001d6e2118429f747daaed006f21ca255bdfbae8200a65341fb68a0ddd7"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "version": "0.14.0-dev.3460+6d29ef0ba",
+        "sha256": "e5536f0f7f716528c3028c67e5c5f1a46673a39ada36cc6ad0a8c9d0d32dd1d4"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3456+00a8742bb.tar.xz",
-        "version": "0.14.0-dev.3456+00a8742bb",
-        "sha256": "7f13822fde5c5cfb7f9c92e9828864c38b15e565f0736dbabad2eb0913a3b1c3"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "version": "0.14.0-dev.3460+6d29ef0ba",
+        "sha256": "edc0888cf736bb8dc7ca22e87fe7d7173fd9beaa3aae63be5cdf2bd2155ed6d3"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3456+00a8742bb.tar.xz",
-        "version": "0.14.0-dev.3456+00a8742bb",
-        "sha256": "91dcb5a019e0a8d53aff25353957df5e385f7c244c625cb1768d6fda5a5d13c9"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "version": "0.14.0-dev.3460+6d29ef0ba",
+        "sha256": "fa0bd7289b2ce2eba261b75a7247700bad5778d366e044d3b310678347ea248b"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3456+00a8742bb.zip",
-        "sha256": "ebecf8e27061bdd7496a1c866da2c8e0d6b38db181d3ebff37fd16b8eae4030f",
-        "version": "0.14.0-dev.3456+00a8742bb"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3460+6d29ef0ba.zip",
+        "sha256": "ebf4a66441536f38a7e810e57410af94f785890e81bd63ef6bacecd959e3e138",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3456+00a8742bb.zip",
-        "sha256": "be5eedd46c98e34e5aaf8518bd09817631f56e300506af3b37332acffb522de1",
-        "version": "0.14.0-dev.3456+00a8742bb"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3460+6d29ef0ba.zip",
+        "sha256": "9c6bc9780f03d2e945d700677d8e67d52c7261f8e0a5d0d2b5d3ff6c03949180",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
       }
     },
     "2021-02-20": {
@@ -23319,6 +23319,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3456+00a8742bb.zip",
         "sha256": "be5eedd46c98e34e5aaf8518bd09817631f56e300506af3b37332acffb522de1",
         "version": "0.14.0-dev.3456+00a8742bb"
+      }
+    },
+    "2025-03-04": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "sha256": "edc0888cf736bb8dc7ca22e87fe7d7173fd9beaa3aae63be5cdf2bd2155ed6d3",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "sha256": "fa0bd7289b2ce2eba261b75a7247700bad5778d366e044d3b310678347ea248b",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "sha256": "b5cdecc1a7f633cc1ea5ed852b0f96f0d8fdbad3096bbdc99ba75b6e547234bc",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.3460+6d29ef0ba.tar.xz",
+        "sha256": "e5536f0f7f716528c3028c67e5c5f1a46673a39ada36cc6ad0a8c9d0d32dd1d4",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.3460+6d29ef0ba.zip",
+        "sha256": "ebf4a66441536f38a7e810e57410af94f785890e81bd63ef6bacecd959e3e138",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.3460+6d29ef0ba.zip",
+        "sha256": "9c6bc9780f03d2e945d700677d8e67d52c7261f8e0a5d0d2b5d3ff6c03949180",
+        "version": "0.14.0-dev.3460+6d29ef0ba"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "version": "0.15.0-dev.62+ea57fb55e",
-        "sha256": "bb8994abbfec3d2afc042da2edba1eea0adb7e30bef07ff2c99fbeab5f0c267e"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "version": "0.15.0-dev.63+aa3db7cc1",
+        "sha256": "1a89e6f49868c614d19af27174ac0b6355589599ed9c6754510ea1bcfb0ae4db"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "version": "0.15.0-dev.62+ea57fb55e",
-        "sha256": "da7d449e34776cfda3527afa351d20158251a5bf24e182cff128cee9bbc35f17"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "version": "0.15.0-dev.63+aa3db7cc1",
+        "sha256": "916f732c7df86e6a9479bc03e751121e547a006362bde526f6cfb58bae26ea2f"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "version": "0.15.0-dev.62+ea57fb55e",
-        "sha256": "361185091f2430d865d8c363b847c541b52ff544569cedbd3c0bc57cdeedaeec"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "version": "0.15.0-dev.63+aa3db7cc1",
+        "sha256": "f27298c809230db40efe2948b3eebd23bc01d2183845105dc9ac7eee6dd39d54"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "version": "0.15.0-dev.62+ea57fb55e",
-        "sha256": "0378e33ddd36363a81138c59e02c4a46a22e6c8c3292cc23ffea485af376aa92"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "version": "0.15.0-dev.63+aa3db7cc1",
+        "sha256": "4fc59c67aca0cb60bca43ae667d4124fe6ae3df9c4a33ba4593116e3f89bc2ca"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.62+ea57fb55e.zip",
-        "sha256": "c5de618597bc5c8e2419e6fcc97767c444cb46f9d7be9a3bf79d9829eb3970b3",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.63+aa3db7cc1.zip",
+        "sha256": "c51d0d5f5fbc458f41d0f8059007d7c56d8f7111ec991b6cb643d72a7fae9385",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.62+ea57fb55e.zip",
-        "sha256": "03e81a2b8cdeb8eeb68fbc3ef3b52dd87fa75ca36dd01f6bb3b0620b7472864f",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.63+aa3db7cc1.zip",
+        "sha256": "e1516739215ede9cacbadaf341e59c0afff846573a24e434994b5e65de792c9d",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       }
     },
     "2021-02-20": {
@@ -23579,34 +23579,34 @@
     },
     "2025-03-16": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "sha256": "361185091f2430d865d8c363b847c541b52ff544569cedbd3c0bc57cdeedaeec",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "sha256": "f27298c809230db40efe2948b3eebd23bc01d2183845105dc9ac7eee6dd39d54",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "sha256": "0378e33ddd36363a81138c59e02c4a46a22e6c8c3292cc23ffea485af376aa92",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "sha256": "4fc59c67aca0cb60bca43ae667d4124fe6ae3df9c4a33ba4593116e3f89bc2ca",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "sha256": "bb8994abbfec3d2afc042da2edba1eea0adb7e30bef07ff2c99fbeab5f0c267e",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "sha256": "1a89e6f49868c614d19af27174ac0b6355589599ed9c6754510ea1bcfb0ae4db",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.62+ea57fb55e.tar.xz",
-        "sha256": "da7d449e34776cfda3527afa351d20158251a5bf24e182cff128cee9bbc35f17",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.63+aa3db7cc1.tar.xz",
+        "sha256": "916f732c7df86e6a9479bc03e751121e547a006362bde526f6cfb58bae26ea2f",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.62+ea57fb55e.zip",
-        "sha256": "c5de618597bc5c8e2419e6fcc97767c444cb46f9d7be9a3bf79d9829eb3970b3",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.63+aa3db7cc1.zip",
+        "sha256": "c51d0d5f5fbc458f41d0f8059007d7c56d8f7111ec991b6cb643d72a7fae9385",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.62+ea57fb55e.zip",
-        "sha256": "03e81a2b8cdeb8eeb68fbc3ef3b52dd87fa75ca36dd01f6bb3b0620b7472864f",
-        "version": "0.15.0-dev.62+ea57fb55e"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.63+aa3db7cc1.zip",
+        "sha256": "e1516739215ede9cacbadaf341e59c0afff846573a24e434994b5e65de792c9d",
+        "version": "0.15.0-dev.63+aa3db7cc1"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
-        "version": "0.15.0-dev.33+539f3effd",
-        "sha256": "8b02d2a7b749a8df1cae5d7091b0ba20028c9c91d32a9c291ad833e191f5fdc2"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "version": "0.15.0-dev.34+8e0a4ca4b",
+        "sha256": "9eab7719e55309a2288cbc14ea0b0c41b14f9a2b09223ee93071972271a3143e"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
-        "version": "0.15.0-dev.33+539f3effd",
-        "sha256": "04d5152d4362f160ad87fd59f1c6b5f14c1f21c7145da62729663c05814c2df0"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "version": "0.15.0-dev.34+8e0a4ca4b",
+        "sha256": "db083c2959f21308095d8c22ad5b6290d214b69e484856d3f939a0a7ecb12d67"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
-        "version": "0.15.0-dev.33+539f3effd",
-        "sha256": "f9022398a154469bc972fc2e164276a1d502c08a747468f610c7add3a069c452"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "version": "0.15.0-dev.34+8e0a4ca4b",
+        "sha256": "200811acea1162cd1380735148e745d851880fff32868e9a042403c57b214f1c"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
-        "version": "0.15.0-dev.33+539f3effd",
-        "sha256": "5baec025de841d62348902e5ea53630732ff87f8c78e28456258aba0fcc2db9e"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "version": "0.15.0-dev.34+8e0a4ca4b",
+        "sha256": "775b95b45e8c47188d0b51e81fa7db045fd54cf9da1ec04e6257a677883286de"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.33+539f3effd.zip",
-        "sha256": "415dd796c0370fabb92a0ae653029897442fe187931adef17b2ae570008d8365",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.34+8e0a4ca4b.zip",
+        "sha256": "cfb2a0bab9503a948fd3d6ea4b1478568f70783ac5404bc7fe119f27b4d7bf5e",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.33+539f3effd.zip",
-        "sha256": "5c0771bc97949cbb5221ae2a27c93ff5b08d43f42c495a5d26f1f25dd0acf4d6",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.34+8e0a4ca4b.zip",
+        "sha256": "688c7d9a7700ecbf75e0a274ff4331e4cbe40644dc7274280f0c41968dc18d84",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       }
     },
     "2021-02-20": {
@@ -23483,34 +23483,34 @@
     },
     "2025-03-10": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
-        "sha256": "f9022398a154469bc972fc2e164276a1d502c08a747468f610c7add3a069c452",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "sha256": "200811acea1162cd1380735148e745d851880fff32868e9a042403c57b214f1c",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
-        "sha256": "5baec025de841d62348902e5ea53630732ff87f8c78e28456258aba0fcc2db9e",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "sha256": "775b95b45e8c47188d0b51e81fa7db045fd54cf9da1ec04e6257a677883286de",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.33+539f3effd.tar.xz",
-        "sha256": "8b02d2a7b749a8df1cae5d7091b0ba20028c9c91d32a9c291ad833e191f5fdc2",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "sha256": "9eab7719e55309a2288cbc14ea0b0c41b14f9a2b09223ee93071972271a3143e",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.33+539f3effd.tar.xz",
-        "sha256": "04d5152d4362f160ad87fd59f1c6b5f14c1f21c7145da62729663c05814c2df0",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
+        "sha256": "db083c2959f21308095d8c22ad5b6290d214b69e484856d3f939a0a7ecb12d67",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.33+539f3effd.zip",
-        "sha256": "415dd796c0370fabb92a0ae653029897442fe187931adef17b2ae570008d8365",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.34+8e0a4ca4b.zip",
+        "sha256": "cfb2a0bab9503a948fd3d6ea4b1478568f70783ac5404bc7fe119f27b4d7bf5e",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.33+539f3effd.zip",
-        "sha256": "5c0771bc97949cbb5221ae2a27c93ff5b08d43f42c495a5d26f1f25dd0acf4d6",
-        "version": "0.15.0-dev.33+539f3effd"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.34+8e0a4ca4b.zip",
+        "sha256": "688c7d9a7700ecbf75e0a274ff4331e4cbe40644dc7274280f0c41968dc18d84",
+        "version": "0.15.0-dev.34+8e0a4ca4b"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.37+423907c27.tar.xz",
-        "version": "0.15.0-dev.37+423907c27",
-        "sha256": "54aa0f93cf6d50c603ec30dfe6d6da4e2c31de2e9ae5b4244fe8450f34bb2dce"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.56+d0911786c.tar.xz",
+        "version": "0.15.0-dev.56+d0911786c",
+        "sha256": "54ef448d32520ca10641f18c4e0a4393f762461d1e351ff075683c391951628d"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.37+423907c27.tar.xz",
-        "version": "0.15.0-dev.37+423907c27",
-        "sha256": "7fc18a341c5c8eed5c3b230658554a8eda46e0dc3e7c129931251848fdeb4a64"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.56+d0911786c.tar.xz",
+        "version": "0.15.0-dev.56+d0911786c",
+        "sha256": "55234d068a5a60851c39052431037762fb3447af691751f826c6faf5ab7d0850"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.37+423907c27.tar.xz",
-        "version": "0.15.0-dev.37+423907c27",
-        "sha256": "9bc9bdc54955140958efb2f7f6ae7b59d331fc59b4d4ddf82d90a982d886275a"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.56+d0911786c.tar.xz",
+        "version": "0.15.0-dev.56+d0911786c",
+        "sha256": "a737bf40b6b4627833c2346f4d1ab63c387e16e70c535cec421029efbf792826"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.37+423907c27.tar.xz",
-        "version": "0.15.0-dev.37+423907c27",
-        "sha256": "17deecdf4c89b2ee92e8d1c5b3ed9236970f76e74c48757a2f255828a0f81732"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.56+d0911786c.tar.xz",
+        "version": "0.15.0-dev.56+d0911786c",
+        "sha256": "ef8f0429fa663c55807a60c3931fddc971276dd4570ca794a81c20c6cabfb56d"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.37+423907c27.zip",
-        "sha256": "9c2d48723b4e7dcade44e73b1f3fc1c49fd99cdba2aab3f19657a01d775dd5b1",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.56+d0911786c.zip",
+        "sha256": "05c71d9a820a883589fc34e2e82d49a7ce1263b5957d58ae83ab9f3de02aae14",
+        "version": "0.15.0-dev.56+d0911786c"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.37+423907c27.zip",
-        "sha256": "4980d7d42f63d23889dcb431a30def25fae652a215cccef065729c1d7e25df9a",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.56+d0911786c.zip",
+        "sha256": "f620259d96ab0d60725ce86dedfe11b1c061acdff1d5f4e4cae5806d9d9477a2",
+        "version": "0.15.0-dev.56+d0911786c"
       }
     },
     "2021-02-20": {
@@ -23515,34 +23515,34 @@
     },
     "2025-03-12": {
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.37+423907c27.tar.xz",
-        "sha256": "9bc9bdc54955140958efb2f7f6ae7b59d331fc59b4d4ddf82d90a982d886275a",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.56+d0911786c.tar.xz",
+        "sha256": "a737bf40b6b4627833c2346f4d1ab63c387e16e70c535cec421029efbf792826",
+        "version": "0.15.0-dev.56+d0911786c"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.37+423907c27.tar.xz",
-        "sha256": "17deecdf4c89b2ee92e8d1c5b3ed9236970f76e74c48757a2f255828a0f81732",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.56+d0911786c.tar.xz",
+        "sha256": "ef8f0429fa663c55807a60c3931fddc971276dd4570ca794a81c20c6cabfb56d",
+        "version": "0.15.0-dev.56+d0911786c"
       },
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.37+423907c27.tar.xz",
-        "sha256": "54aa0f93cf6d50c603ec30dfe6d6da4e2c31de2e9ae5b4244fe8450f34bb2dce",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.56+d0911786c.tar.xz",
+        "sha256": "54ef448d32520ca10641f18c4e0a4393f762461d1e351ff075683c391951628d",
+        "version": "0.15.0-dev.56+d0911786c"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.37+423907c27.tar.xz",
-        "sha256": "7fc18a341c5c8eed5c3b230658554a8eda46e0dc3e7c129931251848fdeb4a64",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.56+d0911786c.tar.xz",
+        "sha256": "55234d068a5a60851c39052431037762fb3447af691751f826c6faf5ab7d0850",
+        "version": "0.15.0-dev.56+d0911786c"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.37+423907c27.zip",
-        "sha256": "9c2d48723b4e7dcade44e73b1f3fc1c49fd99cdba2aab3f19657a01d775dd5b1",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.56+d0911786c.zip",
+        "sha256": "05c71d9a820a883589fc34e2e82d49a7ce1263b5957d58ae83ab9f3de02aae14",
+        "version": "0.15.0-dev.56+d0911786c"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.37+423907c27.zip",
-        "sha256": "4980d7d42f63d23889dcb431a30def25fae652a215cccef065729c1d7e25df9a",
-        "version": "0.15.0-dev.37+423907c27"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.56+d0911786c.zip",
+        "sha256": "f620259d96ab0d60725ce86dedfe11b1c061acdff1d5f4e4cae5806d9d9477a2",
+        "version": "0.15.0-dev.56+d0911786c"
       }
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -36,34 +36,34 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
-        "version": "0.15.0-dev.34+8e0a4ca4b",
-        "sha256": "9eab7719e55309a2288cbc14ea0b0c41b14f9a2b09223ee93071972271a3143e"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.37+423907c27.tar.xz",
+        "version": "0.15.0-dev.37+423907c27",
+        "sha256": "54aa0f93cf6d50c603ec30dfe6d6da4e2c31de2e9ae5b4244fe8450f34bb2dce"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
-        "version": "0.15.0-dev.34+8e0a4ca4b",
-        "sha256": "db083c2959f21308095d8c22ad5b6290d214b69e484856d3f939a0a7ecb12d67"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.37+423907c27.tar.xz",
+        "version": "0.15.0-dev.37+423907c27",
+        "sha256": "7fc18a341c5c8eed5c3b230658554a8eda46e0dc3e7c129931251848fdeb4a64"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
-        "version": "0.15.0-dev.34+8e0a4ca4b",
-        "sha256": "200811acea1162cd1380735148e745d851880fff32868e9a042403c57b214f1c"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.37+423907c27.tar.xz",
+        "version": "0.15.0-dev.37+423907c27",
+        "sha256": "9bc9bdc54955140958efb2f7f6ae7b59d331fc59b4d4ddf82d90a982d886275a"
       },
       "aarch64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.34+8e0a4ca4b.tar.xz",
-        "version": "0.15.0-dev.34+8e0a4ca4b",
-        "sha256": "775b95b45e8c47188d0b51e81fa7db045fd54cf9da1ec04e6257a677883286de"
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.37+423907c27.tar.xz",
+        "version": "0.15.0-dev.37+423907c27",
+        "sha256": "17deecdf4c89b2ee92e8d1c5b3ed9236970f76e74c48757a2f255828a0f81732"
       },
       "x86_64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.34+8e0a4ca4b.zip",
-        "sha256": "cfb2a0bab9503a948fd3d6ea4b1478568f70783ac5404bc7fe119f27b4d7bf5e",
-        "version": "0.15.0-dev.34+8e0a4ca4b"
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.37+423907c27.zip",
+        "sha256": "9c2d48723b4e7dcade44e73b1f3fc1c49fd99cdba2aab3f19657a01d775dd5b1",
+        "version": "0.15.0-dev.37+423907c27"
       },
       "aarch64-windows": {
-        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.34+8e0a4ca4b.zip",
-        "sha256": "688c7d9a7700ecbf75e0a274ff4331e4cbe40644dc7274280f0c41968dc18d84",
-        "version": "0.15.0-dev.34+8e0a4ca4b"
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.37+423907c27.zip",
+        "sha256": "4980d7d42f63d23889dcb431a30def25fae652a215cccef065729c1d7e25df9a",
+        "version": "0.15.0-dev.37+423907c27"
       }
     },
     "2021-02-20": {
@@ -23511,6 +23511,38 @@
         "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.34+8e0a4ca4b.zip",
         "sha256": "688c7d9a7700ecbf75e0a274ff4331e4cbe40644dc7274280f0c41968dc18d84",
         "version": "0.15.0-dev.34+8e0a4ca4b"
+      }
+    },
+    "2025-03-12": {
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.15.0-dev.37+423907c27.tar.xz",
+        "sha256": "9bc9bdc54955140958efb2f7f6ae7b59d331fc59b4d4ddf82d90a982d886275a",
+        "version": "0.15.0-dev.37+423907c27"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.37+423907c27.tar.xz",
+        "sha256": "17deecdf4c89b2ee92e8d1c5b3ed9236970f76e74c48757a2f255828a0f81732",
+        "version": "0.15.0-dev.37+423907c27"
+      },
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.15.0-dev.37+423907c27.tar.xz",
+        "sha256": "54aa0f93cf6d50c603ec30dfe6d6da4e2c31de2e9ae5b4244fe8450f34bb2dce",
+        "version": "0.15.0-dev.37+423907c27"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.15.0-dev.37+423907c27.tar.xz",
+        "sha256": "7fc18a341c5c8eed5c3b230658554a8eda46e0dc3e7c129931251848fdeb4a64",
+        "version": "0.15.0-dev.37+423907c27"
+      },
+      "x86_64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-x86_64-0.15.0-dev.37+423907c27.zip",
+        "sha256": "9c2d48723b4e7dcade44e73b1f3fc1c49fd99cdba2aab3f19657a01d775dd5b1",
+        "version": "0.15.0-dev.37+423907c27"
+      },
+      "aarch64-windows": {
+        "url": "https://ziglang.org/builds/zig-windows-aarch64-0.15.0-dev.37+423907c27.zip",
+        "sha256": "4980d7d42f63d23889dcb431a30def25fae652a215cccef065729c1d7e25df9a",
+        "version": "0.15.0-dev.37+423907c27"
       }
     }
   },

--- a/update
+++ b/update
@@ -6,7 +6,7 @@ set -e
 PUBLIC_KEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
 
 # Grab the JSON and parse the version
-rm -rf index.json index.json.minisig
+rm -rf *index.json zig-index.json.minisig
 curl -s 'https://ziglang.org/download/index.json' > zig-index.json
 VERSION=$(cat zig-index.json | jq -r '.master.version')
 echo "Parsing master version: ${VERSION}"
@@ -15,6 +15,7 @@ echo "Parsing master version: ${VERSION}"
 curl -s "https://ziglang.org/builds/zig-${VERSION}-index.json.minisig" > zig-index.json.minisig
 minisign -V -P ${PUBLIC_KEY} -x zig-index.json.minisig -m zig-index.json
 
+# Merge Mach's index.json with the official one
 curl -s 'https://machengine.org/zig/index.json' > mach-index.json
 jq -s '.[0] * .[1]' mach-index.json zig-index.json > index.json
 

--- a/update
+++ b/update
@@ -7,13 +7,16 @@ PUBLIC_KEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
 
 # Grab the JSON and parse the version
 rm -rf index.json index.json.minisig
-curl -s 'https://ziglang.org/download/index.json' > index.json
-VERSION=$(cat index.json | jq -r '.master.version')
+curl -s 'https://ziglang.org/download/index.json' > zig-index.json
+VERSION=$(cat zig-index.json | jq -r '.master.version')
 echo "Parsing master version: ${VERSION}"
 
 # Verify the signature of the JSON before we parse it
-curl -s "https://ziglang.org/builds/zig-${VERSION}-index.json.minisig" > index.json.minisig
-minisign -V -P ${PUBLIC_KEY} -x index.json.minisig -m index.json
+curl -s "https://ziglang.org/builds/zig-${VERSION}-index.json.minisig" > zig-index.json.minisig
+minisign -V -P ${PUBLIC_KEY} -x zig-index.json.minisig -m zig-index.json
+
+curl -s 'https://machengine.org/zig/index.json' > mach-index.json
+jq -s '.[0] * .[1]' mach-index.json zig-index.json > index.json
 
 # Build our new sources.json
 cat index.json | jq '
@@ -35,7 +38,7 @@ def toentry(vsn; x):
 reduce to_entries[] as $entry ({}; . * (
   $entry | {
     (.key): (
-      if (.key != "master") then
+      if (.key != "master" and .key != "mach-latest") then
         toentry(.key; .value)
       else {
         "latest": toentry(.value.version; .value),


### PR DESCRIPTION
https://machengine.org/docs/nominated-zig/

Many projects (even ones that don't use Mach directly) are starting to use Mach's nominated version scheme. They are identical to their respective Zig master versions but are stored on Mach's mirror.