### PR TITLE
flake: inputs: remove flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,24 +16,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1708161998,
@@ -53,27 +35,11 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_2"
+        "systems": "systems"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "flake": false,
       "locked": {
         "lastModified": 1681028828,

--- a/flake.lock
+++ b/flake.lock
@@ -54,10 +54,27 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    systems = {
+      url = "github:nix-systems/default";
+      flake = false;
+    };
     flake-utils.url = "github:numtide/flake-utils";
 
     # Used for shell.nix
@@ -15,11 +19,11 @@
   outputs = {
     self,
     nixpkgs,
+    systems,
     flake-utils,
     ...
   }: let
-    systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
-    outputs = flake-utils.lib.eachSystem systems (system: let
+    outputs = flake-utils.lib.eachSystem (import systems) (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in rec {
       # The packages exported by the Flake:

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
       url = "github:nix-systems/default";
       flake = false;
     };
-    flake-utils.url = "github:numtide/flake-utils";
 
     # Used for shell.nix
     flake-compat = {
@@ -20,58 +19,64 @@
     self,
     nixpkgs,
     systems,
-    flake-utils,
     ...
   }: let
-    outputs = flake-utils.lib.eachSystem (import systems) (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in rec {
-      # The packages exported by the Flake:
-      #  - default - latest /released/ version
-      #  - <version> - tagged version
-      #  - master - latest nightly (updated daily)
-      #  - master-<date> - nightly by date
-      packages = import ./default.nix {inherit system pkgs;};
+    inherit (nixpkgs) lib;
 
-      # "Apps" so that `nix run` works. If you run `nix run .` then
-      # this will use the latest default.
-      apps = rec {
-        default = apps.zig;
-        zig = flake-utils.lib.mkApp {drv = packages.default;};
-      };
+    eachSystem = lib.genAttrs (import systems);
 
-      # nix fmt
-      formatter = pkgs.alejandra;
+    pkgsFor = eachSystem (system: nixpkgs.legacyPackages.${system});
+  in {
+    # The packages exported by the Flake:
+    #  - default - latest /released/ version
+    #  - <version> - tagged version
+    #  - master - latest nightly (updated daily)
+    #  - master-<date> - nightly by date
+    packages = lib.mapAttrs (system: pkgs: import ./default.nix {inherit system pkgs;}) pkgsFor;
 
-      devShells.default = pkgs.mkShell {
-        nativeBuildInputs = with pkgs; [
-          curl
-          jq
-          minisign
-        ];
-      };
-
-      # For compatibility with older versions of the `nix` binary
-      devShell = self.devShells.${system}.default;
-    });
-  in
-    outputs
-    // {
-      # Overlay that can be imported so you can access the packages
-      # using zigpkgs.master or whatever you'd like.
-      overlays.default = final: prev: {
-        zigpkgs = outputs.packages.${prev.system};
-      };
-
-      # Templates for use with nix flake init
-      templates.compiler-dev = {
-        path = ./templates/compiler-dev;
-        description = "A development environment for Zig compiler development.";
-      };
-
-      templates.init = {
-        path = ./templates/init;
-        description = "A basic, empty development environment.";
-      };
+    # Overlay that can be imported so you can access the packages
+    # using zigpkgs.master or whatever you'd like.
+    overlays.default = final: prev: {
+      zigpkgs = self.packages.${prev.system};
     };
+
+    # "Apps" so that `nix run` works. If you run `nix run .` then
+    # this will use the latest default.
+    apps = eachSystem (system: {
+      default = self.apps.${system}.zig;
+      zig = {
+        type = "app";
+        program = self.packages.${system}.default.outPath;
+      };
+    });
+
+    # nix fmt
+    formatter = lib.mapAttrs (_: pkgs: pkgs.alejandra) pkgsFor;
+
+    devShells =
+      lib.mapAttrs (system: pkgs: {
+        default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            curl
+            jq
+            minisign
+          ];
+        };
+      })
+      pkgsFor;
+
+    # For compatibility with older versions of the `nix` binary
+    devShell = eachSystem (system: self.devShells.${system}.default);
+
+    # Templates for use with nix flake init
+    templates.compiler-dev = {
+      path = ./templates/compiler-dev;
+      description = "A development environment for Zig compiler development.";
+    };
+
+    templates.init = {
+      path = ./templates/init;
+      description = "A basic, empty development environment.";
+    };
+  };
 }


### PR DESCRIPTION
You don't need it.

This pull-request supercedes
<https://github.com/mitchellh/zig-overlay/pull/60>,
which copies a function from `flake-utils`.

Instead of using this (arguably bad) abstraction,
introduce `eachSystem` and `pkgsFor`.

I see that you use merge commits, and squash people's changes, so if you want me to make a separate pull-request for ee9cba5c35c2f5586f4a0e749308a0c167e715fd, just let me know. It is technically an independent change, and if you haven't seen the pattern before, might warrant some explanation.