### PR TITLE
Updating README.md with a command to run a specific zig version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ $ nix run 'github:mitchellh/zig-overlay'
 $ nix shell 'github:mitchellh/zig-overlay#master-2021-02-13'
 # open a shell with latest nightly version
 $ nix shell 'github:mitchellh/zig-overlay#master'
+# open a shell with a specific zig version
+$ nix shell 'github:mitchellh/zig-overlay#"0.14.0"'
 ```
 
 ### Compiler Development


### PR DESCRIPTION
This is a small change, but it would have saved me time if it were already there.

I am new to nix, and it took me some time to figure out the correct syntax for getting a specific zig version—specifically, the quotes around the version number.