### PR TITLE
fix: update compiler-dev flake LLVM from 20 to 21

### DIFF
--- a/templates/compiler-dev/flake.nix
+++ b/templates/compiler-dev/flake.nix
@@ -2,7 +2,7 @@
   description = "Zig compiler development.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
 
     # Used for shell.nix
@@ -33,7 +33,7 @@
               wasmtime
               zlib
             ]
-            ++ (with llvmPackages_20; [
+            ++ (with llvmPackages_21; [
               clang
               clang-unwrapped
               lld


### PR DESCRIPTION
Update compiler-dev flake LLVM version according to [building from source](https://github.com/ziglang/zig?tab=readme-ov-file#building-from-source) requirements.

Also changed `nixpkgs.url` because no matching version (21) was found in `nixpkgs-unstable`.