### PR TITLE
verify signature against versioned index.json

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,6 @@ jobs:
       - run: "git config user.email mitchellh@users.noreply.github.com"
       - run: "git config user.name zig-overlay"
       - run: "git add -A"
-      - run: "git commit -m 'update sources.json' | true"
+      - run: "git commit -m 'update sources.json' || true"
       - run: "git push -u origin main"
 

--- a/update
+++ b/update
@@ -13,12 +13,14 @@ curl -s 'https://ziglang.org/download/index.json' > index.json
 VERSION=$(cat index.json | jq -r '.master.version')
 echo "Parsing master version: ${VERSION}"
 
-# Verify the signature of the JSON before we parse it
+# Download the versioned index.json and its signature, then verify.
+# The signature is generated against the versioned file, not the generic one.
+curl -s "https://ziglang.org/builds/zig-${VERSION}-index.json" > versioned-index.json
 curl -s "https://ziglang.org/builds/zig-${VERSION}-index.json.minisig" > index.json.minisig
-minisign -V -P ${PUBLIC_KEY} -x index.json.minisig -m index.json
+minisign -V -P ${PUBLIC_KEY} -x index.json.minisig -m versioned-index.json
 
-# Build our new sources.json
-cat index.json | jq '
+# Build our new sources.json from the verified index
+cat versioned-index.json | jq '
 ["aarch64-linux", "x86_64-linux", "aarch64-macos", "x86_64-macos", "aarch64-windows", "x86_64-windows"] as $targets |
 def todarwin(x): x | gsub("macos"; "darwin");
 def toentry(vsn; x):
@@ -57,3 +59,6 @@ cp sources.json sources.old.json
 
 # Recursive merge
 jq -s '.[0] * .[1]' sources.old.json sources.new.json > sources.json
+
+# Clean up temp files
+rm -f index.json versioned-index.json index.json.minisig sources.old.json sources.new.json


### PR DESCRIPTION
The minisig file is generated against the versioned zig-${VERSION}-index.json, not the generic /download/index.json. The generic file is a living document that gets overwritten with each new Zig build, so its contents may not match what was signed at the time of verification. Download the versioned copy from /builds/ and verify against that instead.

This fixes 0.16 validation.