### PR TITLE
fix: update compiler-dev flake with LLVM 22

### DIFF
--- a/templates/compiler-dev/flake.nix
+++ b/templates/compiler-dev/flake.nix
@@ -2,7 +2,7 @@
   description = "Zig compiler development.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
     # Used for shell.nix
@@ -33,7 +33,7 @@
               wasmtime
               zlib
             ]
-            ++ (with llvmPackages_21; [
+            ++ (with llvmPackages_22; [
               clang
               clang-unwrapped
               lld


### PR DESCRIPTION
The latest version of the zig compiler `0.17-dev` uses LLVM 22 over 21. This commit updates the flake LLVM version and changes the `nixpkgs.url` back to use `nixpkgs-unstable`, as LLVM 22 is not present on `nixos-25.11`